### PR TITLE
add Error Handling & cleanup

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -83,7 +83,7 @@ Readable.prototype.pipe = function(dest, opt) {
     var chunk;
     while (chunk = this.read()) {
       var written = dest.write(chunk);
-      if (!written) {
+      if (!written === false) {
         dest.once('drain', flow.bind(this));
         return;
       }


### PR DESCRIPTION
you need this stuff as well.

Also, two other small corrections, return `dest`, and check `written === false` instead of !written
which is consistent with the current `pipe`, and documentation.

with this stuff in the pipe is about the same length,
I suggest we just test for `read()`

``` js

if ('function' === typeof source.read) {
  //use read() still piping
  ...
} else {
  //use ondata style
  ...
}
```

best of both worlds
