### PR TITLE
Have readable.pipe() return dest

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -38,6 +38,8 @@ Readable.prototype.pipe = function(dest, opt) {
     }
     this.once('readable', flow);
   }
+  
+  return dest;
 };
 
 // kludge for on('data', fn) consumers.  Sad.


### PR DESCRIPTION
return the dest so that pipes can be chained x.pipe(y).pipe(z)
