### PR TITLE
backport to 0.6.x

### DIFF
--- a/from-list.js
+++ b/from-list.js
@@ -4,6 +4,36 @@
 // the length is the sum of all the buffers in the list.
 
 module.exports = fromList;
+if(!Buffer.hasOwnProperty('concat')){
+	Buffer.concat = function(list, length) {
+	  if (!Array.isArray(list)) {
+	    throw new Error('Usage: Buffer.concat(list, [length])');
+	  }
+
+	  if (list.length === 0) {
+	    return new Buffer(0);
+	  } else if (list.length === 1) {
+	    return list[0];
+	  }
+
+	  if (typeof length !== 'number') {
+	    length = 0;
+	    for (var i = 0; i < list.length; i++) {
+	      var buf = list[i];
+	      length += buf.length;
+	    }
+	  }
+
+	  var buffer = new Buffer(length);
+	  var pos = 0;
+	  for (var i = 0; i < list.length; i++) {
+	    var buf = list[i];
+	    buf.copy(buffer, pos);
+	    pos += buf.length;
+	  }
+	  return buffer;
+	};
+}
 
 function fromList(n, list, length) {
   var ret;

--- a/fs.js
+++ b/fs.js
@@ -36,7 +36,7 @@ util.inherits(FSReadable, Readable);
 function FSReadable(path, options) {
   if (!options) options = {};
 
-  Readable.apply(this, options);
+  Readable.call(this, options);
 
   this.path = path;
   this.flags = 'r';


### PR DESCRIPTION
I define Buffer.concat if it is not already defined in from-list.js.  Also changed Readable.apply(this, options) to Readable.call(this, options) in fs.js since options is an object not an array.  (It was causing a test to fail in 0.6)
