### PR TITLE
expose wrap

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -28,6 +28,12 @@ var StringDecoder;
 
 util.inherits(Readable, Stream);
 
+Readable.wrap = wrap
+
+function wrap(source) {
+  return new Readable().wrap(source);
+}
+
 function ReadableState(options) {
   options = options || {};
 
@@ -460,6 +466,8 @@ Readable.prototype.wrap = function(stream) {
 
     return ret;
   };
+
+  return this;
 };
 
 


### PR DESCRIPTION
We want wrap to be easy.

In 0.10 I want to be able to do this

``` js
var wrap = require("stream").wrap
    , oldModule = require("old-module")

var s = wrap(oldModule.createStream())

var chunk = s.read()
```
