### PR TITLE
fix regression in Readable::wrap()

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -600,7 +600,7 @@ Readable.prototype.wrap = function(stream) {
   stream.on('data', function(chunk) {
     if (state.decoder)
       chunk = state.decoder.write(chunk);
-    if (!chunk || !chunk.length)
+    if (!chunk)
       return;
 
     state.buffer.push(chunk);


### PR DESCRIPTION
Since v0.0.4 Readable::wrap() requires a length property on
received chunks before emitting a readable event.

A MongoDB CursorStream emits objects in it's data event that lack a
length property resulting in no readable events when wrapped around
the new 0.0.4 wrapper.

Not sure about the best solution or the importance of a correct
length value, but this simple patch reverts back to 0.0.3 behavior.
