### PR TITLE
Preliminary work for objectStream

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -60,6 +60,7 @@ function ReadableState(options, stream) {
   this.buffer = [];
   this.length = 0;
   this.pipes = null;
+  this.objectStream = options.objectStream || false
   this.pipesCount = 0;
   this.flowing = false;
   this.ended = false;
@@ -114,6 +115,9 @@ Readable.prototype.setEncoding = function(enc) {
 function howMuchToRead(n, state) {
   if (state.length === 0 && state.ended)
     return 0;
+
+  if (state.objectStream)
+    return 1;
 
   if (isNaN(n) || n === null)
     return state.length;
@@ -202,7 +206,7 @@ Readable.prototype.read = function(n) {
 
   var ret;
   if (n > 0)
-    ret = fromList(n, state.buffer, state.length, !!state.decoder);
+    ret = fromList(n, state.buffer, state.length, !!state.decoder, state);
   else
     ret = null;
 
@@ -229,14 +233,14 @@ function onread(stream, er, chunk) {
   if (er)
     return stream.emit('error', er);
 
-  if (!chunk || !chunk.length) {
+  if (!chunk || (!state.objectStream && !chunk.length)) {
     // eof
     state.ended = true;
     if (state.decoder) {
       chunk = state.decoder.end && state.decoder.end();
       if (chunk && chunk.length) {
         state.buffer.push(chunk);
-        state.length += chunk.length;
+        state.length += state.objectStream ? 1 : chunk.length;
       }
     }
     // if we've ended and we have some data left, then emit
@@ -259,7 +263,7 @@ function onread(stream, er, chunk) {
 
   // update the buffer info.
   if (chunk) {
-    state.length += chunk.length;
+    state.length += state.objectStream ? 1 : chunk.length;
     state.buffer.push(chunk);
   }
 
@@ -409,7 +413,6 @@ function flow(src) {
 
   while (state.pipesCount &&
          null !== (chunk = src.read(state.pipeChunkSize))) {
-
     if (state.pipesCount === 1)
       write(state.pipes, 0, null);
     else
@@ -655,7 +658,7 @@ Readable.prototype.wrap = function(stream) {
         n = state.length;
     }
 
-    var ret = fromList(n, state.buffer, state.length, !!state.decoder);
+    var ret = fromList(n, state.buffer, state.length, !!state.decoder, state);
     state.length -= n;
 
     if (state.length === 0 && !state.ended)
@@ -680,7 +683,7 @@ Readable._fromList = fromList;
 
 // Pluck off n bytes from an array of buffers.
 // Length is the combined lengths of all the buffers in the list.
-function fromList(n, list, length, stringMode) {
+function fromList(n, list, length, stringMode, state) {
   var ret;
 
   // nothing in the list, definitely empty.
@@ -690,6 +693,8 @@ function fromList(n, list, length, stringMode) {
 
   if (length === 0)
     ret = null;
+  else if (state.objectStream)
+    ret = list.shift()
   else if (!n || n >= length) {
     // read it all, truncate the array.
     if (stringMode)


### PR DESCRIPTION
This makes [read-stream work with usage of `._readableState.onread`][1]

It's a start. Far from done or clean.

  [1]: https://github.com/Raynos/read-stream/tree/streams2._read
