### PR TITLE
remove require("assert")

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -27,7 +27,6 @@ module.exports = Writable;
 Writable.WritableState = WritableState;
 
 var util = require('util');
-var assert = require('assert');
 var Stream = require('stream');
 var Duplex = require('./_stream_duplex');
 


### PR DESCRIPTION
The `assert` module is never actually used in `_stream_writable.js`, but was required anyway. Such is no longer the case.
