### PR TITLE
Always check for availablity of decoder.end()

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -737,7 +737,7 @@ Readable.prototype.wrap = function(stream) {
   var self = this;
   stream.on('end', function() {
     state.ended = true;
-    if (state.decoder) {
+    if (state.decoder && state.decoder.end) {
       var chunk = state.decoder.end();
       if (chunk && chunk.length)
         self.push(chunk);


### PR DESCRIPTION
Otherwise it will fail on node v0.8.x
