### PR TITLE
Require Duplex earlier

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -30,6 +30,8 @@ var util = require('util');
 var assert = require('assert');
 var Stream = require('stream');
 
+var Duplex = require('./_stream_duplex');
+
 util.inherits(Writable, Stream);
 
 function WriteReq(chunk, encoding, cb) {
@@ -104,7 +106,7 @@ function WritableState(options, stream) {
 function Writable(options) {
   // Writable ctor is applied to Duplexes, though they're not
   // instanceof Writable, they're instanceof Readable.
-  if (!(this instanceof Writable) && !(this instanceof require('./_stream_duplex')))
+  if (!(this instanceof Writable) && !(this instanceof Duplex))
     return new Writable(options);
 
   this._writableState = new WritableState(options, this);


### PR DESCRIPTION
I'm seeing test failures in bower where [the `instanceof` check](https://github.com/isaacs/readable-stream/blob/8625e8fc8a06866c2e389f4ee97433f465e873aa/lib/_stream_writable.js#L107) for Duplex is false when the entire test suite is run and true when a subset is run (see bower/bower#537).

I'm curious if this could be due to a difference in the way the circular dependency (`_stream_duplex` <-> `_stream_writable`) is resolved.  While I don't have a satisfactory explanation, requiring earlier (as in ff16057244d8c87dbc218a4165a0b7dec69de0fc) makes the bower tests pass consistently for me.
