### PR TITLE
Return self from wrap

### DIFF
--- a/examples/typer.js
+++ b/examples/typer.js
@@ -1,8 +1,7 @@
 var fs = require('fs');
 var fst = fs.createReadStream(__filename);
 var Readable = require('../readable.js');
-var rst = new Readable();
-rst.wrap(fst);
+var rst = new Readable().wrap(fst);
 
 rst.on('end', function() {
   process.stdin.pause();

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -784,6 +784,8 @@ Readable.prototype.wrap = function(stream) {
       paused = false;
     }
   };
+
+  return self;
 };
 
 


### PR DESCRIPTION
Elsewhere (docs and Node 0.10) the wrap method returns the stream itself.
