### PR TITLE
Expose the native 'stream' module if you are on 0.10+.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+
+var stream = require('stream');
+
+if (stream.Readable) {
+  module.exports = stream;
+} else {
+  module.exports = require('./readable.js');
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "readable-stream",
   "version": "1.1.8",
   "description": "An exploration of a new kind of readable streams for Node.js",
-  "main": "readable.js",
+  "main": "index.js",
   "dependencies": {
     "core-util-is": "~1.0.0"
   },


### PR DESCRIPTION
The most common pattern when dealing with supporting with 0.8 and 0.10 is

```
var Readable     = require('stream').Readable || require('readable-stream').Readable
```

Directly from levelup: https://github.com/rvagg/node-levelup/blob/master/lib/read-stream.js#L6

We are all wiriting these lines over and over again. Why just not returning the native module?
