### PR TITLE
use core-string-decoder as a dependency

### DIFF
--- a/build/files.js
+++ b/build/files.js
@@ -16,20 +16,27 @@ const requireReplacement = [
             return 'instanceof require(\'./_stream_' + streamType.toLowerCase() + '\')'
           }
       ]
+    , stringDecoderReplacement = [
+          /(require\(['"])string_decoder(['"]\))/g
+        , '$1core-string-decoder$2'
+      ]
 
 module.exports['_stream_duplex.js'] = [
     requireReplacement
   , instanceofReplacement
+  , stringDecoderReplacement
 ]
 
 module.exports['_stream_passthrough.js'] = [
     requireReplacement
   , instanceofReplacement
+  , stringDecoderReplacement
 ]
 
 module.exports['_stream_readable.js'] = [
     requireReplacement
   , instanceofReplacement
+  , stringDecoderReplacement
 
   , [
         /(require\('events'\)\.EventEmitter;)/
@@ -49,9 +56,11 @@ module.exports['_stream_readable.js'] = [
 module.exports['_stream_transform.js'] = [
     requireReplacement
   , instanceofReplacement
+  , stringDecoderReplacement
 ]
 
 module.exports['_stream_writable.js'] = [
     requireReplacement
   , instanceofReplacement
+  , stringDecoderReplacement
 ]

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -94,7 +94,7 @@ function ReadableState(options, stream) {
   this.encoding = null;
   if (options.encoding) {
     if (!StringDecoder)
-      StringDecoder = require('string_decoder').StringDecoder;
+      StringDecoder = require('core-string-decoder').StringDecoder;
     this.decoder = new StringDecoder(options.encoding);
     this.encoding = options.encoding;
   }
@@ -195,7 +195,7 @@ function needMoreData(state) {
 // backwards compatibility.
 Readable.prototype.setEncoding = function(enc) {
   if (!StringDecoder)
-    StringDecoder = require('string_decoder').StringDecoder;
+    StringDecoder = require('core-string-decoder').StringDecoder;
   this._readableState.decoder = new StringDecoder(enc);
   this._readableState.encoding = enc;
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.24",
   "description": "An exploration of a new kind of readable streams for Node.js",
   "main": "readable.js",
-  "dependencies": {},
+  "dependencies": {
+    "core-string-decoder": "~0.10.x"
+  },
   "devDependencies": {
     "tap": "~0.2.6"
   },


### PR DESCRIPTION
@isaacs would you have objections to using _core-string-decoder_ instead of core's _string_decoder_? I'll keep it updated in the same way, versioned like Node core (although unlikely to actually change much, or at all between versions).

See discussion https://github.com/joyent/node/pull/6830 about the 0.8 compatibility issues; it'd be awesome if we could solve this in user-land.

@substack already has _string_decoder_ in npm but that's not going to help us override the `require('string_decoder')`. I'd like to see if we can unify the two packages (https://github.com/substack/string_decoder/pull/1).
