### PR TITLE
RFC: No need for setImmediate/clearImmediate polyfill

### DIFF
--- a/build/files.js
+++ b/build/files.js
@@ -60,12 +60,6 @@ module.exports['_stream_readable.js'] = [
       ,   '$1\n'
         + 'if (!EE.listenerCount) EE.listenerCount = function(emitter, type) {\n'
         + '  return emitter.listeners(type).length;\n'
-        + '};\n\n'
-        + 'if (!global.setImmediate) global.setImmediate = function setImmediate(fn) {\n'
-        + '  return setTimeout(fn, 0);\n'
-        + '};\n'
-        + 'if (!global.clearImmediate) global.clearImmediate = function clearImmediate(i) {\n'
-        + '  return clearTimeout(i);\n'
         + '};\n'
 
     ]


### PR DESCRIPTION
These aren't used in readable-stream anywhere so the polyfill is unnecessary at the least.

Some of the tests will need them for 0.8 support but I'll do them in the test replacements.
