### PR TITLE
fix transform/writable for browserify

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -30,6 +30,7 @@ var util = require('util');
 var Buffer = require('buffer').Buffer;
 var assert = require('assert');
 var Stream = require('stream');
+var Duplex = require('./_stream_duplex');
 
 util.inherits(Writable, Stream);
 
@@ -113,7 +114,7 @@ function WritableState(options, stream) {
 function Writable(options) {
   // Writable ctor is applied to Duplexes, though they're not
   // instanceof Writable, they're instanceof Readable.
-  if (!(this instanceof Writable) && !(this instanceof require('./_stream_duplex')))
+  if (!(this instanceof Writable) && !(this instanceof Duplex))
     return new Writable(options);
 
   this._writableState = new WritableState(options, this);


### PR DESCRIPTION
with `readable-stream@1.0.26` if you try and browserify this and then run it:

```
var Transform = require('readable-stream/transform')()
```

then you get `Error: Cannot find module './_stream_duplex'`

this fixes it (not sure why honestly)
