### PR TITLE
require('stream') early

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -1,3 +1,4 @@
+require('stream'); // hack to fix a circular dependency issue when used with browserify
 exports = module.exports = require('./lib/_stream_readable.js');
 exports.Readable = exports;
 exports.Writable = require('./lib/_stream_writable.js');


### PR DESCRIPTION
In the latest version of browserify the following does not work

``` js
var Duplex = require('readable-stream').Duplex
var stream = new Duplex() // returns an error because .once is undefined
```

The issue seem to be because of a circular dependency somewhere.
It is fixed by doing `require('stream')` early
