### PR TITLE
Cached stream reference

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -1,6 +1,6 @@
-require('stream'); // hack to fix a circular dependency issue when used with browserify
+var Stream = require('stream'); // hack to fix a circular dependency issue when used with browserify
 exports = module.exports = require('./lib/_stream_readable.js');
-exports.Stream = require('stream');
+exports.Stream = Stream;
 exports.Readable = exports;
 exports.Writable = require('./lib/_stream_writable.js');
 exports.Duplex = require('./lib/_stream_duplex.js');


### PR DESCRIPTION
I added this to cache the stream reference saving Browserify from doing a redundant dependency look up.
