### PR TITLE
Add .destroy to Readable and Writable prototypes

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -108,6 +108,8 @@ function ReadableState(options, stream) {
     this.decoder = new StringDecoder(options.encoding);
     this.encoding = options.encoding;
   }
+
+  this.destroyed = false;
 }
 
 function Readable(options) {
@@ -150,6 +152,28 @@ Readable.prototype.unshift = function(chunk) {
 
 Readable.prototype.isPaused = function() {
   return this._readableState.flowing === false;
+};
+
+Readable.prototype.destroy = function() {
+  var self = this;
+  if (this._readableState.destroyed) return;
+  this._readableState.destroyed = true;
+
+  // if this is a duplex stream mark the writable part as destroyed as well
+  if (this._writableState) {
+    this._writableState.destroyed = true;
+  }
+
+  this._destroy(function(err) {
+    if (err) {
+      self.emit('error', err);
+    }
+    self.emit('close');
+  });
+};
+
+Readable.prototype._destroy = function (callback) {
+  process.nextTick(callback)
 };
 
 function readableAddChunk(stream, state, chunk, encoding, addToFront) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -127,6 +127,8 @@ function WritableState(options, stream) {
 
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
+
+  this.destroyed = false;
 }
 
 WritableState.prototype.getBuffer = function writableStateGetBuffer() {
@@ -244,6 +246,23 @@ Writable.prototype.uncork = function() {
         state.bufferedRequest)
       clearBuffer(this, state);
   }
+};
+
+// More or less the same destroy method as in Readable
+Writable.prototype.destroy = function() {
+  var self = this;
+  if (this._writableState.destroyed) return;
+  this._writableState.destroyed = true;
+  this._destroy(function(err) {
+    if (err) {
+      self.emit('error', err);
+    }
+    self.emit('close');
+  });
+};
+
+Writable.prototype._destroy = function (callback) {
+  process.nextTick(callback);
 };
 
 Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {


### PR DESCRIPTION
This is an attempt to implement #124. Basically it adds `.destroy` to the Readable and Writable prototypes. These prototypes forwards the call to `._destroy(cb)` the first time destroy is called. If destroy is called twice the second call is ignored.

This allows you prematurely end a stream more easily. As an example here is a file reader

``` js
var createFileStream = function (fd) {
  var rs = new stream.Readable()

  rs._destroy = function (cb) {
    fs.close(fd, cb)
  }

  rs._read = function (size) {
    var buf = new Buffer(size)
    fs.read(fd, buf, 0, size, null, function (err, len) {
      if (err) {
        rs.emit('error', err)
        return rs.destroy()
      }
      rs.push(buf.slice(0, len))
    })
  }

  return rs
}
``` 

Calling `rs.destroy()` will now close the file descriptor and emit `close` when the close is done.