### PR TITLE
update with work done on io.js 2.0.0

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -121,6 +121,9 @@ function Readable(options) {
   // legacy
   this.readable = true;
 
+  if (options && typeof options.read === 'function')
+    this._read = options.read;
+
   Stream.call(this);
 }
 
@@ -131,7 +134,7 @@ function Readable(options) {
 Readable.prototype.push = function(chunk, encoding) {
   var state = this._readableState;
 
-  if (util.isString(chunk) && !state.objectMode) {
+  if (!state.objectMode && typeof chunk === 'string') {
     encoding = encoding || state.defaultEncoding;
     if (encoding !== state.encoding) {
       chunk = new Buffer(chunk, encoding);
@@ -158,8 +161,7 @@ function readableAddChunk(stream, state, chunk, encoding, addToFront) {
     stream.emit('error', er);
   } else if (chunk === null) {
     state.reading = false;
-    if (!state.ended)
-      onEofChunk(stream, state);
+    onEofChunk(stream, state);
   } else if (state.objectMode || chunk && chunk.length > 0) {
     if (state.ended && !addToFront) {
       var e = new Error('stream.push() after EOF');
@@ -245,7 +247,7 @@ function howMuchToRead(n, state) {
   if (state.objectMode)
     return n === 0 ? 0 : 1;
 
-  if (util.isNull(n) || isNaN(n)) {
+  if (n === null || isNaN(n)) {
     // only flow one buffer at a time
     if (state.flowing && state.buffer.length)
       return state.buffer[0].length;
@@ -281,7 +283,7 @@ Readable.prototype.read = function(n) {
   var state = this._readableState;
   var nOrig = n;
 
-  if (!util.isNumber(n) || n > 0)
+  if (typeof n !== 'number' || n > 0)
     state.emittedReadable = false;
 
   // if we're doing read(0) to trigger a readable event, but we
@@ -369,7 +371,7 @@ Readable.prototype.read = function(n) {
   else
     ret = null;
 
-  if (util.isNull(ret)) {
+  if (ret === null) {
     state.needReadable = true;
     n = 0;
   }
@@ -385,7 +387,7 @@ Readable.prototype.read = function(n) {
   if (nOrig !== n && state.ended && state.length === 0)
     endReadable(this);
 
-  if (!util.isNull(ret))
+  if (ret !== null)
     this.emit('data', ret);
 
   return ret;
@@ -393,9 +395,10 @@ Readable.prototype.read = function(n) {
 
 function chunkInvalid(state, chunk) {
   var er = null;
-  if (!util.isBuffer(chunk) &&
-      !util.isString(chunk) &&
-      !util.isNullOrUndefined(chunk) &&
+  if (!(chunk instanceof Buffer) &&
+      typeof chunk !== 'string' &&
+      chunk !== null &&
+      chunk !== undefined &&
       !state.objectMode) {
     er = new TypeError('Invalid non-string/buffer chunk');
   }
@@ -404,7 +407,8 @@ function chunkInvalid(state, chunk) {
 
 
 function onEofChunk(stream, state) {
-  if (state.decoder && !state.ended) {
+  if (state.ended) return;
+  if (state.decoder) {
     var chunk = state.decoder.end();
     if (chunk && chunk.length) {
       state.buffer.push(chunk);
@@ -793,7 +797,6 @@ Readable.prototype.wrap = function(stream) {
       chunk = state.decoder.write(chunk);
 
     // don't skip over falsy values in objectMode
-    //if (state.objectMode && util.isNullOrUndefined(chunk))
     if (state.objectMode && (chunk === null || chunk === undefined))
       return;
     else if (!state.objectMode && (!chunk || !chunk.length))
@@ -809,7 +812,7 @@ Readable.prototype.wrap = function(stream) {
   // proxy all the other methods.
   // important when wrapping filters and duplexes.
   for (var i in stream) {
-    if (util.isFunction(stream[i]) && util.isUndefined(this[i])) {
+    if (this[i] === undefined && typeof stream[i] === 'function') {
       this[i] = function(method) { return function() {
         return stream[method].apply(stream, arguments);
       }}(i);

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -77,7 +77,7 @@ function afterTransform(stream, er, data) {
   ts.writechunk = null;
   ts.writecb = null;
 
-  if (!util.isNullOrUndefined(data))
+  if (data !== null && data !== undefined)
     stream.push(data);
 
   if (cb)
@@ -110,8 +110,16 @@ function Transform(options) {
   // sync guard flag.
   this._readableState.sync = false;
 
+  if (options) {
+    if (typeof options.transform === 'function')
+      this._transform = options.transform;
+
+    if (typeof options.flush === 'function')
+      this._flush = options.flush;
+  }
+
   this.once('prefinish', function() {
-    if (util.isFunction(this._flush))
+    if (typeof this._flush === 'function')
       this._flush(function(er) {
         done(stream, er);
       });
@@ -159,7 +167,7 @@ Transform.prototype._write = function(chunk, encoding, cb) {
 Transform.prototype._read = function(n) {
   var ts = this._transformState;
 
-  if (!util.isNull(ts.writechunk) && ts.writecb && !ts.transforming) {
+  if (ts.writechunk !== null && ts.writecb && !ts.transforming) {
     ts.transforming = true;
     this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
   } else {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -33,6 +33,8 @@ if (debug && debug.debuglog) {
 
 util.inherits(Writable, Stream);
 
+function nop() {}
+
 function WriteReq(chunk, encoding, cb) {
   this.chunk = chunk;
   this.encoding = encoding;
@@ -159,6 +161,14 @@ function Writable(options) {
   // legacy.
   this.writable = true;
 
+  if (options) {
+    if (typeof options.write === 'function')
+      this._write = options.write;
+
+    if (typeof options.writev === 'function')
+      this._writev = options.writev;
+  }
+
   Stream.call(this);
 }
 
@@ -168,7 +178,7 @@ Writable.prototype.pipe = function() {
 };
 
 
-function writeAfterEnd(stream, state, cb) {
+function writeAfterEnd(stream, cb) {
   var er = new Error('write after end');
   // TODO: defer error events consistently everywhere, not just the cb
   stream.emit('error', er);
@@ -184,9 +194,10 @@ function writeAfterEnd(stream, state, cb) {
 // how many bytes or characters.
 function validChunk(stream, state, chunk, cb) {
   var valid = true;
-  if (!util.isBuffer(chunk) &&
-      !util.isString(chunk) &&
-      !util.isNullOrUndefined(chunk) &&
+  if (!(chunk instanceof Buffer) &&
+      typeof chunk !== 'string' &&
+      chunk !== null &&
+      chunk !== undefined &&
       !state.objectMode) {
     var er = new TypeError('Invalid non-string/buffer chunk');
     stream.emit('error', er);
@@ -202,21 +213,21 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
 
-  if (util.isFunction(encoding)) {
+  if (typeof encoding === 'function') {
     cb = encoding;
     encoding = null;
   }
 
-  if (util.isBuffer(chunk))
+  if (chunk instanceof Buffer)
     encoding = 'buffer';
   else if (!encoding)
     encoding = state.defaultEncoding;
 
-  if (!util.isFunction(cb))
-    cb = function() {};
+  if (typeof cb !== 'function')
+    cb = nop;
 
   if (state.ended)
-    writeAfterEnd(this, state, cb);
+    writeAfterEnd(this, cb);
   else if (validChunk(this, state, chunk, cb)) {
     state.pendingcb++;
     ret = writeOrBuffer(this, state, chunk, encoding, cb);
@@ -258,7 +269,7 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 function decodeChunk(state, chunk, encoding) {
   if (!state.objectMode &&
       state.decodeStrings !== false &&
-      util.isString(chunk)) {
+      typeof chunk === 'string') {
     chunk = new Buffer(chunk, encoding);
   }
   return chunk;
@@ -269,7 +280,7 @@ function decodeChunk(state, chunk, encoding) {
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, chunk, encoding, cb) {
   chunk = decodeChunk(state, chunk, encoding);
-  if (util.isBuffer(chunk))
+  if (chunk instanceof Buffer)
     encoding = 'buffer';
   var len = state.objectMode ? 1 : chunk.length;
 
@@ -340,7 +351,7 @@ function onwrite(stream, er) {
     onwriteError(stream, state, sync, er, cb);
   else {
     // Check if we're actually ready to finish, but don't emit yet
-    var finished = needFinish(stream, state);
+    var finished = needFinish(state);
 
     if (!finished &&
         !state.corked &&
@@ -441,16 +452,16 @@ Writable.prototype._writev = null;
 Writable.prototype.end = function(chunk, encoding, cb) {
   var state = this._writableState;
 
-  if (util.isFunction(chunk)) {
+  if (typeof chunk === 'function') {
     cb = chunk;
     chunk = null;
     encoding = null;
-  } else if (util.isFunction(encoding)) {
+  } else if (typeof encoding === 'function') {
     cb = encoding;
     encoding = null;
   }
 
-  if (!util.isNullOrUndefined(chunk))
+  if (chunk !== null && chunk !== undefined)
     this.write(chunk, encoding);
 
   // .end() fully uncorks
@@ -465,7 +476,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
 };
 
 
-function needFinish(stream, state) {
+function needFinish(state) {
   return (state.ending &&
           state.length === 0 &&
           state.bufferedRequest === null &&
@@ -481,7 +492,7 @@ function prefinish(stream, state) {
 }
 
 function finishMaybe(stream, state) {
-  var need = needFinish(stream, state);
+  var need = needFinish(state);
   if (need) {
     if (state.pendingcb === 0) {
       prefinish(stream, state);

--- a/test/parallel/test-stream-push-order.js
+++ b/test/parallel/test-stream-push-order.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var Readable = require('../../').Readable;
 var assert = require('assert');
 

--- a/test/parallel/test-stream-readable-constructor-set-methods.js
+++ b/test/parallel/test-stream-readable-constructor-set-methods.js
@@ -1,0 +1,18 @@
+var common = require('../common');
+var assert = require('assert');
+
+var Readable = require('../../lib/_stream_readable');
+
+var _readCalled = false;
+function _read(n) {
+  _readCalled = true;
+  this.push(null);
+}
+
+var r = new Readable({ read: _read });
+r.resume();
+
+process.on('exit', function () {
+  assert.equal(r._read, _read);
+  assert(_readCalled);
+});

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -1,0 +1,31 @@
+var common = require('../common');
+var assert = require('assert');
+
+var Transform = require('../../lib/_stream_transform');
+
+var _transformCalled = false;
+function _transform(d, e, n) {
+  _transformCalled = true;
+  n();
+}
+
+var _flushCalled = false;
+function _flush(n) {
+  _flushCalled = true;
+  n();
+}
+
+var t = new Transform({
+  transform: _transform,
+  flush: _flush
+});
+
+t.end(new Buffer('blerg'));
+t.resume();
+
+process.on('exit', function () {
+  assert.equal(t._transform, _transform);
+  assert.equal(t._flush, _flush);
+  assert(_transformCalled);
+  assert(_flushCalled);
+});

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -1,0 +1,34 @@
+var common = require('../common');
+var assert = require('assert');
+
+var Writable = require('../../lib/_stream_writable');
+
+var _writeCalled = false;
+function _write(d, e, n) {
+  _writeCalled = true;
+}
+
+var w = new Writable({ write: _write });
+w.end(new Buffer('blerg'));
+
+var _writevCalled = false;
+var dLength = 0;
+function _writev(d, n) {
+  dLength = d.length;
+  _writevCalled = true;
+}
+
+var w2 = new Writable({ writev: _writev });
+w2.cork();
+
+w2.write(new Buffer('blerg'));
+w2.write(new Buffer('blerg'));
+w2.end();
+
+process.on('exit', function () {
+  assert.equal(w._write, _write);
+  assert(_writeCalled);
+  assert.equal(w2._writev, _writev);
+  assert.equal(dLength, 2);
+  assert(_writevCalled);
+});

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var R = require('../../lib/_stream_readable');
 var W = require('../../lib/_stream_writable');
 var assert = require('assert');

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var R = require('../../lib/_stream_readable');
 var assert = require('assert');
 

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var stream = require('../../');
 var Buffer = require('buffer').Buffer;
 

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 
 // If everything aligns so that you do a read(n) of exactly the

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var Readable = require('../../lib/_stream_readable');
 var Writable = require('../../lib/_stream_writable');
 var assert = require('assert');

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 
 var util = require('util');

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var stream = require('../../');
 var Readable = stream.Readable;
 var Writable = stream.Writable;

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 var fromList = require('../../lib/_stream_readable')._fromList;
 
 // tiny node-tap lookalike.

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 var Readable = require('../../lib/_stream_readable');
 
 var len = 0;

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var R = require('../../lib/_stream_readable');
 var util = require('util');

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 var PassThrough = require('../../lib/_stream_passthrough');
 var Transform = require('../../lib/_stream_transform');
 

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var stream = require('../../');
 var crypto = require('crypto');

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var stream = require('../../');
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var W = require('../../lib/_stream_writable');
 var D = require('../../lib/_stream_duplex');
 var assert = require('assert');


### PR DESCRIPTION
includes:
- most removal of is* functions
- renaming requires for '../common.js' to '../common'
- add simpler stream constructon (without subclassing) + tests
- remove a duplicated expression in lib/_stream_readable
- remove unused variables in lib/_stream_writable
- use nop as write() callback if omitted in lib/_stream_writable

I omitted the changes requiring process.nextTick to accept multiple args, and the addition of `_stream_wrap` for now.