### PR TITLE
browserify compatibility

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -32,7 +32,7 @@ if (!EE.listenerCount) EE.listenerCount = function(emitter, type) {
 var Stream;
  (function (){try{
 Stream = require('st' + 'ream');
-}catch(_){Stream = require('events').EventEmitter;}}())
+}catch(_){}finally{if (!Stream) Stream = require('events').EventEmitter;}}())
 /*</replacement>*/
 
 var Buffer = require('buffer').Buffer;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -29,7 +29,7 @@ util.inherits = require('inherits');
 var Stream;
  (function (){try{
 Stream = require('st' + 'ream');
-}catch(_){Stream = require('events').EventEmitter;}}())
+}catch(_){}finally{if (!Stream) Stream = require('events').EventEmitter;}}())
 /*</replacement>*/
 
 var Buffer = require('buffer').Buffer;


### PR DESCRIPTION
Fixes https://github.com/substack/node-browserify/issues/1312. After this I can bump stream-browserify to ^2.0.0 in browserify.