### PR TITLE
Move require out of constructor to top of module

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -37,6 +37,8 @@ var Stream;
 
 var Buffer = require('buffer').Buffer;
 
+var Duplex = require('./_stream_duplex');
+
 util.inherits(Writable, Stream);
 
 function nop() {}
@@ -49,8 +51,6 @@ function WriteReq(chunk, encoding, cb) {
 }
 
 function WritableState(options, stream) {
-  var Duplex = require('./_stream_duplex');
-
   options = options || {};
 
   // object stream flag to indicate whether or not this stream
@@ -158,8 +158,6 @@ Object.defineProperty(WritableState.prototype, 'buffer', {
 
 
 function Writable(options) {
-  var Duplex = require('./_stream_duplex');
-
   // Writable ctor is applied to Duplexes, though they're not
   // instanceof Writable, they're instanceof Readable.
   if (!(this instanceof Writable) && !(this instanceof Duplex))


### PR DESCRIPTION
This provides a big performance improvement.

The Stream module code in current Node no longer has this issue.