### PR TITLE
Do not overwrite module var

### DIFF
--- a/build/files.js
+++ b/build/files.js
@@ -49,9 +49,10 @@ const headRegexp = /(^module.exports = \w+;?)/m
 
     , debugLogReplacement = [
           /var debug = util.debuglog\('stream'\);/
-      ,   '\n\n/*<replacement>*/\nvar debug = require(\'util\');\n'
-        + 'if (debug && debug.debuglog) {\n'
-        + '  debug = debug.debuglog(\'stream\');\n'
+      ,   '\n\n/*<replacement>*/\nvar debugUtil = require(\'util\');\n'
+        + 'var debug;\n'
+        + 'if (debugUtil && debugUtil.debuglog) {\n'
+        + '  debug = debugUtil.debuglog(\'stream\');\n'
         + '} else {\n'
         + '  debug = function () {};\n'
         + '}\n/*</replacement>*/\n'


### PR DESCRIPTION
Minor change here to prevent a variable pointing to a module from being overwritten.

https://github.com/facebook/fbjs/blob/master/scripts/babel/inline-requires.js#L74-L91 checks for this and throws an error. 

`fbjs-scripts` module is used by https://github.com/facebook/react-native and this is causing tests to fail. 

This is one angle I am attempting to fix this issue. Why `fbjs-scripts` is throwing an error in this case is another matter that I will look into as well. This case may very well exist in other node modules. But in this specific case it was an easy change with basically no impact. 

Please consider accepting this change. Thanks!