### PR TITLE
perf fix for Duplex require replacement

### DIFF
--- a/build/files.js
+++ b/build/files.js
@@ -31,9 +31,11 @@ const headRegexp = /(^module.exports = \w+;?)/m
         , '$1\n\n/*<replacement>*/\nvar Buffer = require(\'buffer\').Buffer;\n/*</replacement>*/\n'
       ]
 
+      // The browser build ends up with a circular dependency, so the require is
+      // done lazily, but cached.
     , addDuplexRequire = [
           /^(function (?:Writable|Readable)(?:State)?.*{)/gm
-        , '$1\n  var Duplex = require(\'./_stream_duplex\');\n'
+        , 'var Duplex;\n$1\n  Duplex = Duplex || require(\'./_stream_duplex\');\n'
       ]
 
     , altForEachImplReplacement = require('./common-replacements').altForEachImplReplacement


### PR DESCRIPTION
I was noticing that RegExps called from Module._resolveLookupPaths were getting
to be the hottest symbol in some profiles. readable-stream seems to be requiring
Duplex from inside functions. It would be faster to not do a require on each
invocation of Readable, ReadableState, Writable, WritableState.