### PR TITLE
Identify corresponding node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # readable-stream
 
-***Node-core streams for userland*** [![Build Status](https://travis-ci.org/nodejs/readable-stream.svg?branch=master)](https://travis-ci.org/nodejs/readable-stream)
+***Node-core v0.0.0 streams for userland*** [![Build Status](https://travis-ci.org/nodejs/readable-stream.svg?branch=master)](https://travis-ci.org/nodejs/readable-stream)
 
 
 [![NPM](https://nodei.co/npm/readable-stream.png?downloads=true&downloadRank=true)](https://nodei.co/npm/readable-stream/)

--- a/build/build.js
+++ b/build/build.js
@@ -6,8 +6,13 @@ const hyperquest  = require('hyperzip')(require('hyperdirect'))
     , path        = require('path')
     , cheerio     = require('cheerio')
     , encoding    = 'utf8'
+    , urlRegex = /^https?:\/\//
     , nodeVersion = process.argv[2]
     , nodeVersionRegexString = '\\d+\\.\\d+\\.\\d+'
+    , usageVersionRegex = RegExp('^' + nodeVersionRegexString + '$')
+    , readmeVersionRegex =
+        RegExp('(Node-core v)' + nodeVersionRegexString, 'g')
+
     , readmePath  = path.join(__dirname, '..', 'README.md')
     , files       = require('./files')
     , testReplace = require('./test-replacements')
@@ -23,14 +28,14 @@ const hyperquest  = require('hyperzip')(require('hyperdirect'))
     , docourroot  = path.join(__dirname, '../doc')
 
 
-if (!RegExp('^' + nodeVersionRegexString + '$').test(nodeVersion)) {
+if (!usageVersionRegex.test(nodeVersion)) {
   console.error('Usage: build.js xx.yy.zz')
   return process.exit(1);
 }
 
 // `inputLoc`: URL or local path.
 function processFile (inputLoc, out, replacements) {
-  var file = /^https?:\/\//.test(inputLoc) ?
+  var file = urlRegex.test(inputLoc) ?
     hyperquest(inputLoc) :
     fs.createReadStream(inputLoc, encoding)
 
@@ -107,8 +112,5 @@ processFile(
 // Update Node version in README
 
 processFile(readmePath, readmePath, [
-  [
-      RegExp('(Node-core v)' + nodeVersionRegexString, 'g')
-    , "$1" + nodeVersion
-  ]
+  [readmeVersionRegex, "$1" + nodeVersion]
 ])

--- a/build/build.js
+++ b/build/build.js
@@ -5,39 +5,39 @@ const hyperquest  = require('hyperzip')(require('hyperdirect'))
     , fs          = require('fs')
     , path        = require('path')
     , cheerio     = require('cheerio')
-
+    , encoding    = 'utf8'
+    , nodeVersion = process.argv[2]
+    , nodeVersionRegexString = '\\d+\\.\\d+\\.\\d+'
     , files       = require('./files')
     , testReplace = require('./test-replacements')
     , docReplace  = require('./doc-replacements')
 
-    , srcurlpfx   = `https://raw.githubusercontent.com/nodejs/node/v${process.argv[2]}/`
+    , srcurlpfx   = `https://raw.githubusercontent.com/nodejs/node/v${nodeVersion}/`
     , libsrcurl   = srcurlpfx + 'lib/'
     , testsrcurl  = srcurlpfx + 'test/parallel/'
-    , testlisturl = `https://github.com/nodejs/node/tree/v${process.argv[2]}/test/parallel`
+    , testlisturl = `https://github.com/nodejs/node/tree/v${nodeVersion}/test/parallel`
     , libourroot  = path.join(__dirname, '../lib/')
     , testourroot = path.join(__dirname, '../test/parallel/')
-    , docurlpfx   = `https://raw.githubusercontent.com/nodejs/node/v${process.argv[2]}/doc/api/`
+    , docurlpfx   = `https://raw.githubusercontent.com/nodejs/node/v${nodeVersion}/doc/api/`
     , docourroot  = path.join(__dirname, '../doc')
 
 
-if (!/\d\.\d\.\d+/.test(process.argv[2])) {
+if (!RegExp('^' + nodeVersionRegexString + '$').test(nodeVersion)) {
   console.error('Usage: build.js xx.yy.zz')
   return process.exit(1);
 }
 
 function processFile (url, out, replacements) {
   hyperquest(url).pipe(bl(function (err, data) {
-    if (err)
-      throw err
+    if (err) throw err
 
     data = data.toString()
     replacements.forEach(function (replacement) {
       data = data.replace.apply(data, replacement)
     })
 
-    fs.writeFile(out, data, 'utf8', function (err) {
-      if (err)
-        throw err
+    fs.writeFile(out, data, encoding, function (err) {
+      if (err) throw err
 
       console.log('Wrote', out)
     })
@@ -63,13 +63,6 @@ function processTestFile (file) {
 
   processFile(url, out, replacements)
 }
-
-
-if (!/\d\.\d\.\d+/.test(process.argv[2])) {
-  console.log('Usage: build.js <node version>')
-  return process.exit(-1)
-}
-
 
 //--------------------------------------------------------------------
 // Grab & process files in ../lib/

--- a/build/build.js
+++ b/build/build.js
@@ -8,6 +8,7 @@ const hyperquest  = require('hyperzip')(require('hyperdirect'))
     , encoding    = 'utf8'
     , nodeVersion = process.argv[2]
     , nodeVersionRegexString = '\\d+\\.\\d+\\.\\d+'
+    , readmePath  = path.join(__dirname, '..', 'README.md')
     , files       = require('./files')
     , testReplace = require('./test-replacements')
     , docReplace  = require('./doc-replacements')
@@ -101,3 +102,13 @@ processFile(
   , path.join(testourroot, '../common.js')
   , testReplace['common.js']
 )
+
+//--------------------------------------------------------------------
+// Update Node version in README
+
+processFile(readmePath, readmePath, [
+  [
+      RegExp('(Node-core v)' + nodeVersionRegexString, 'g')
+    , "$1" + nodeVersion
+  ]
+])

--- a/build/build.js
+++ b/build/build.js
@@ -27,8 +27,13 @@ if (!RegExp('^' + nodeVersionRegexString + '$').test(nodeVersion)) {
   return process.exit(1);
 }
 
-function processFile (url, out, replacements) {
-  hyperquest(url).pipe(bl(function (err, data) {
+// `inputLoc`: URL or local path.
+function processFile (inputLoc, out, replacements) {
+  var file = /^https?:\/\//.test(inputLoc) ?
+    hyperquest(inputLoc) :
+    fs.createReadStream(inputLoc, encoding)
+
+  file.pipe(bl(function (err, data) {
     if (err) throw err
 
     data = data.toString()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "readable-stream",
   "version": "2.0.5",
-  "description": "Streams3, a user-land copy of the stream library from iojs v2.x",
+  "description": "Streams3, a user-land copy of the stream library from Node.js",
   "main": "readable.js",
   "dependencies": {
     "core-util-is": "~1.0.0",


### PR DESCRIPTION
I was looking for what version of Node the package corresponds to and noticed the outdated `package.json` `description`. Looks like currently you have to check the commit log to see what the corresponding Node version is. What do you think about putting that in the `README` (as PRed here)? That'd require a bit more maintenance effort but would surface the information better as you could see it on npmjs.com / via `$ npm show readable-stream@2.0.5 readme | head` (assuming it doesn't [display outdated `README` content](https://github.com/npm/npm/issues/10652)), and even make it slightly easier to get on GitHub.