### PR TITLE
fixed the function call for asyncWrite

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -346,7 +346,9 @@ function onwrite(stream, er) {
 
     if (sync) {
       /*<replacement>*/
-      asyncWrite(afterWrite, stream, state, finished, cb);
+      asyncWrite(function() {
+        afterWrite(stream, state, finished, cb);
+      });
       /*</replacement>*/
     } else {
         afterWrite(stream, state, finished, cb);


### PR DESCRIPTION
Hi,

the "asyncWrite" is actually a process.NextTick or setImmediate. So the usage in the async after write process is wrong in my opinion, and causes a Problem for me (currently working on a React native Project).

If you need further information, just contact me.
@stockulus on twitter or stockulus@icloud.com  

Thanks.
Christoph
