### PR TITLE
Pass Number.MAX_SAFE_INTEGER to stream.read to improve performance

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -737,7 +737,7 @@ function flow(stream) {
   debug('flow', state.flowing);
   if (state.flowing) {
     do {
-      var chunk = stream.read();
+      var chunk = stream.read(Number.MAX_SAFE_INTEGER || 9007199254740991);
     } while (null !== chunk && state.flowing);
   }
 }


### PR DESCRIPTION
I discovered this issue while working on a totally different project that uses pdfmake.

See bpampuch/pdfmake/issues/280 for more details.

By passing `Number.MAX_SAFE_INTEGER` to `stream.read` in the `flow()` function, performance improved by several orders of magnitude for really, really large amounts of data.

Thoughts?