### PR TITLE
handle arbitrary EE implementations

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -55,10 +55,8 @@ var StringDecoder;
 
 util.inherits(Readable, Stream);
 
-var hasPrependListener = typeof EE.prototype.prependListener === 'function';
-
 function prependListener(emitter, event, fn) {
-  if (hasPrependListener) return emitter.prependListener(event, fn);
+  if (typeof emitter.prototype.prependListener === 'function') return emitter.prependListener(event, fn);
 
   // This is a brutally ugly hack to make sure that our error handler
   // is attached before any userland ones.  NEVER DO THIS. This is here


### PR DESCRIPTION
Currently, if an emitter that does not inherit from EventEmitter is passed, an error will be thrown:

`Error: emitter.prependListener is not a function`

This PR checks for the existence of prependListener on the emitter that is passed in.