### PR TITLE
Remove isarray dep.

### DIFF
--- a/build/files.js
+++ b/build/files.js
@@ -70,16 +70,6 @@ const headRegexp = /(^module.exports = \w+;?)/m
         + '}catch(_){}}());\n'
       ]
 
-    , isArrayDefine = [
-          headRegexp
-        , '$1\n\n/*<replacement>*/\nvar isArray = require(\'isarray\');\n/*</replacement>*/\n'
-      ]
-
-    , isArrayReplacement = [
-          /Array\.isArray/g
-        , 'isArray'
-      ]
-
     , objectKeysDefine = require('./common-replacements').objectKeysDefine
 
     , objectKeysReplacement = require('./common-replacements').objectKeysReplacement
@@ -220,8 +210,6 @@ module.exports['_stream_readable.js'] = [
   , altIndexOfUseReplacement
   , instanceofReplacement
   , stringDecoderReplacement
-  , isArrayDefine
-  , isArrayReplacement
   , debugLogReplacement
   , utilReplacement
   , stringDecoderReplacement

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -6,10 +6,6 @@ module.exports = Readable;
 var processNextTick = require('process-nextick-args');
 /*</replacement>*/
 
-/*<replacement>*/
-var isArray = require('isarray');
-/*</replacement>*/
-
 Readable.ReadableState = ReadableState;
 
 /*<replacement>*/
@@ -64,7 +60,7 @@ function prependListener(emitter, event, fn) {
     // userland ones.  NEVER DO THIS. This is here only because this code needs
     // to continue to work with older versions of Node.js that do not include
     // the prependListener() method. The goal is to eventually remove this hack.
-    if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
+    if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (Array.isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "buffer-shims": "^1.0.0",
     "core-util-is": "~1.0.0",
     "inherits": "~2.0.1",
-    "isarray": "~1.0.0",
     "process-nextick-args": "~1.0.6",
     "string_decoder": "~0.10.x",
     "util-deprecate": "~1.0.1"


### PR DESCRIPTION
I know it's been brought up a few times (#212) but I think it's time again.

The [isarray](https://www.npmjs.com/package/isarray) package [is being deprecated](https://github.com/juliangruber/isarray/issues/10) since IE < 11 is no longer supported by MS & IE 8 was the last browser that needed it.

The `Array.isArray` method is supported by all Node versions, Rhino, iOS, Android, and headless browser enviros (like PhantomJS v1, SlimerJS).
