### PR TITLE
revert bundled dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,6 @@
     "tape": "~4.5.1",
     "zuul": "~3.10.0"
   },
-  "bundledDependencies": [
-    "buffer-shims",
-    "core-util-is",
-    "isarray",
-    "process-nextick-args",
-    "util-deprecate"
-  ],
   "scripts": {
     "test": "tap test/parallel/*.js test/ours/*.js",
     "browser": "npm run write-zuul && zuul --browser-retries 2 -- test/browser.js",


### PR DESCRIPTION
looks like there are some issues with globals or something, basically this is breaking yarn yarnpkg/yarn#1774 so I plan on publishing this as 2.2.1 pretty shortly