### PR TITLE
Exclude `stream` module in browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "pipe"
   ],
   "browser": {
-    "util": false,
-    "stream": false
+    "util": false
   },
+  "react-native": {
+    "stream": false 
+  }
   "nyc": {
     "include": [
       "lib/**.js"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "pipe"
   ],
   "browser": {
-    "util": false
+    "util": false,
+    "stream": false
   },
   "nyc": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "react-native": {
     "stream": false 
-  }
+  },
   "nyc": {
     "include": [
       "lib/**.js"


### PR DESCRIPTION
React Native complains about the call to `require('st' + 'ream')` in `readable.js` with `Unable to resolve module 'stream' from 'bla bla bla/readable-stream/readable.js'`. The `stream` module isn't needed for browsers as far as I can tell, and keeping it as-is means that any module relying on streams within the context of react-native is broken unless you jump through a long line of hoops.

So far I've had issues with this in the context of the `mqtt` and `bl` modules, however there's loads of modules out there that will also have these problems.