### PR TITLE
Fixed 'Invalid non-string/buffer chunk' error when using Uint8Array

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -394,11 +394,10 @@ Readable.prototype.read = function (n) {
 };
 
 function chunkInvalid(state, chunk) {
-  var er = null;
-  if (!Buffer.isBuffer(chunk) && typeof chunk !== 'string' && chunk !== null && chunk !== undefined && !state.objectMode) {
-    er = new TypeError('Invalid non-string/buffer chunk');
-  }
-  return er;
+  if (chunk || Buffer.isBuffer(chunk) || typeof chunk === 'string' || chunk instanceof Uint8Array  || state.objectMode)
+    return null;
+
+  return new TypeError('Invalid non-string/buffer chunk');
 }
 
 function onEofChunk(stream, state) {


### PR DESCRIPTION
Using 'new Buffer' on a Uint8Array does not create a Buffer object, but adding a Uint8Array chunk is supported by the library, so I added a check to the validation to allow this