### PR TITLE
Avoid caret during installation, and added node v0.6 to .travis.yml

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Streams3, a user-land copy of the stream library from Node.js",
   "main": "readable.js",
   "dependencies": {
-    "buffer-shims": "^1.0.0",
+    "buffer-shims": "~1.0.0",
     "core-util-is": "~1.0.0",
     "isarray": "~1.0.0",
     "inherits": "~2.0.1",


### PR DESCRIPTION
For some context, I would like mysql to use the latest readable-stream: https://github.com/mysqljs/mysql/pull/1677