### PR TITLE
Pull node 7.8.0. test passes w/ READABLE_STREAM=disable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save readable-stream
 This package is a mirror of the Streams2 and Streams3 implementations in
 Node-core.
 
-Full documentation may be found on the [Node.js website](https://nodejs.org/dist/v7.7.3/docs/api/).
+Full documentation may be found on the [Node.js website](https://nodejs.org/dist/v7.8.0/docs/api/).
 
 If you want to guarantee a stable streams base, regardless of what version of
 Node you, or the users of your libraries are using, use **readable-stream** *only* and avoid the *"stream"* module in Node-core, for background see [this blogpost](http://r.va.gg/2014/06/why-i-dont-use-nodes-core-stream-module.html).

--- a/build/test-replacements.js
+++ b/build/test-replacements.js
@@ -304,3 +304,10 @@ module.exports['test-stream-buffer-list.js'] = [
     'require(\'../../lib/internal/streams/BufferList\');'
   ]
 ]
+
+module.exports['test-stream-transform-constructor-set-methods.js'] = [
+  [
+    /Error: _transform\\\(\\\) is n/,
+    'Error: .*[Nn]'
+  ]
+]

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -60,6 +60,8 @@ var StringDecoder;
 
 util.inherits(Readable, Stream);
 
+var kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];
+
 function prependListener(emitter, event, fn) {
   // Sadly this is not cacheable as some libraries bundle their own
   // event emitter implementation with them.
@@ -784,10 +786,9 @@ Readable.prototype.wrap = function (stream) {
   }
 
   // proxy certain important events.
-  var events = ['error', 'close', 'destroy', 'pause', 'resume'];
-  forEach(events, function (ev) {
-    stream.on(ev, self.emit.bind(self, ev));
-  });
+  for (var n = 0; n < kProxyEvents.length; n++) {
+    stream.on(kProxyEvents[n], self.emit.bind(self, kProxyEvents[n]));
+  }
 
   // when we try to consume some more bytes, simply unpause the
   // underlying stream.

--- a/test/common.js
+++ b/test/common.js
@@ -257,26 +257,6 @@ exports.ddCommand = function (filename, kilobytes) {
   }
 };
 
-exports.spawnCat = function (options) {
-  var spawn = require('child_process').spawn;
-
-  if (exports.isWindows) {
-    return spawn('more', [], options);
-  } else {
-    return spawn('cat', [], options);
-  }
-};
-
-exports.spawnSyncCat = function (options) {
-  var spawnSync = require('child_process').spawnSync;
-
-  if (exports.isWindows) {
-    return spawnSync('more', [], options);
-  } else {
-    return spawnSync('cat', [], options);
-  }
-};
-
 exports.spawnPwd = function (options) {
   var spawn = require('child_process').spawn;
 

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -30,7 +30,7 @@ t.resume();
 
 assert.throws(function () {
   t2.end(bufferShim.from('blerg'));
-}, /^Error: _transform\(\) is not implemented$/);
+}, /^Error: .*[Nn]ot implemented$/);
 
 process.on('exit', function () {
   assert.strictEqual(t._transform, _transform);


### PR DESCRIPTION
Nothing much to do here, but citgm should now pass with `READABLE_STREAM=disable` if they have 2.2.7 in their dependency tree.