### PR TITLE
Attempt to test on IE 7 & 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
   - node_js: 8
     env: TASK=test
   - node_js: 6
-    env: TASK=browser BROWSER_NAME=ie BROWSER_VERSION="9..latest"
+    env: TASK=browser BROWSER_NAME=ie BROWSER_VERSION="7..latest"
   - node_js: 6
     env: TASK=browser BROWSER_NAME=opera BROWSER_VERSION="11..latest"
   - node_js: 6


### PR DESCRIPTION
This may not actually run the browser tests unless you pull it down locally or recreate it yourself in a branch on the original project rather than my fork -- I believe Travis + SauceLabs does not test PRs unless you've set it up to use JWT, for instance. I also don't know for certain that the test usage matches Mocha's Browserify-based usage.

That being said, *if* older versions of IE are meant to be supported we may as well try to see all the possible errors in one go instead of repeatedly running Mocha's tests and finding the next compatibility problem; hopefully this is a move in that direction.

(See #293 for discussion so far, and the latest example is:
https://travis-ci.org/mochajs/mocha/jobs/243848563#L2346
https://github.com/nodejs/readable-stream/blob/master/lib/_stream_readable.js#L189
)