### PR TITLE
Partially solves perf issues with the UInt8Array checks.

### DIFF
--- a/build/files.js
+++ b/build/files.js
@@ -185,7 +185,7 @@ function _uint8ArrayToBuffer(chunk) {
    return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Buffer.isBuffer(obj) || (typeof obj !== 'string' && obj instanceof OurUint8Array);
+  return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
 }
 /*</replacement>*/
   `

--- a/build/files.js
+++ b/build/files.js
@@ -184,7 +184,7 @@ function _uint8ArrayToBuffer(chunk) {
    return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Object.prototype.toString.call(obj) === '[object Uint8Array]' || Buffer.isBuffer(obj);
+  return Buffer.isBuffer(obj) || (typeof obj !== 'string' && Object.prototype.toString.call(obj) === '[object Uint8Array]');
 }
 /*</replacement>*/
   `

--- a/build/files.js
+++ b/build/files.js
@@ -180,11 +180,12 @@ const headRegexp = /(^module.exports = \w+;?)/m
       /(?:var|const) Buffer = require\('buffer'\)\.Buffer;/
     , `/*<replacement>*/
   const Buffer = require('safe-buffer').Buffer
+  const OurUint8Array = global.Uint8Array || function () {}
 function _uint8ArrayToBuffer(chunk) {
    return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Buffer.isBuffer(obj) || (typeof obj !== 'string' && Object.prototype.toString.call(obj) === '[object Uint8Array]');
+  return Buffer.isBuffer(obj) || (typeof obj !== 'string' && obj instanceof OurUint8Array);
 }
 /*</replacement>*/
   `

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -54,11 +54,12 @@ var Stream = require('./internal/streams/stream');
 // properly optimized away early in Ignition+TurboFan.
 /*<replacement>*/
 var Buffer = require('safe-buffer').Buffer;
+var OurUint8Array = global.Uint8Array || function () {};
 function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Buffer.isBuffer(obj) || typeof obj !== 'string' && Object.prototype.toString.call(obj) === '[object Uint8Array]';
+  return Buffer.isBuffer(obj) || typeof obj !== 'string' && obj instanceof OurUint8Array;
 }
 /*</replacement>*/
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -59,7 +59,7 @@ function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Buffer.isBuffer(obj) || typeof obj !== 'string' && obj instanceof OurUint8Array;
+  return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
 }
 /*</replacement>*/
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -58,7 +58,7 @@ function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Object.prototype.toString.call(obj) === '[object Uint8Array]' || Buffer.isBuffer(obj);
+  return Buffer.isBuffer(obj) || typeof obj !== 'string' && Object.prototype.toString.call(obj) === '[object Uint8Array]';
 }
 /*</replacement>*/
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -84,7 +84,7 @@ function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Object.prototype.toString.call(obj) === '[object Uint8Array]' || Buffer.isBuffer(obj);
+  return Buffer.isBuffer(obj) || typeof obj !== 'string' && Object.prototype.toString.call(obj) === '[object Uint8Array]';
 }
 /*</replacement>*/
 
@@ -408,26 +408,15 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
 
 function onwriteError(stream, state, sync, er, cb) {
   --state.pendingcb;
+  if (sync) processNextTick(afterError, stream, state, cb, er);else afterError(stream, state, cb, er);
 
-  if (sync) {
-    // defer the callback if we are being called synchronously
-    // to avoid piling up things on the stack
-    processNextTick(cb, er);
-    // this can emit finish, and it will always happen
-    // after error
-    processNextTick(finishMaybe, stream, state);
-    stream._writableState.errorEmitted = true;
-    stream.emit('error', er);
-  } else {
-    // the caller expect this to happen before if
-    // it is async
-    cb(er);
-    stream._writableState.errorEmitted = true;
-    stream.emit('error', er);
-    // this can emit finish, but finish must
-    // always follow error
-    finishMaybe(stream, state);
-  }
+  stream._writableState.errorEmitted = true;
+  stream.emit('error', er);
+}
+
+function afterError(stream, state, cb, err) {
+  cb(err);
+  finishMaybe(stream, state);
 }
 
 function onwriteStateUpdate(state) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -80,11 +80,12 @@ var Stream = require('./internal/streams/stream');
 
 /*<replacement>*/
 var Buffer = require('safe-buffer').Buffer;
+var OurUint8Array = global.Uint8Array || function () {};
 function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Buffer.isBuffer(obj) || typeof obj !== 'string' && Object.prototype.toString.call(obj) === '[object Uint8Array]';
+  return Buffer.isBuffer(obj) || typeof obj !== 'string' && obj instanceof OurUint8Array;
 }
 /*</replacement>*/
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -85,7 +85,7 @@ function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
 }
 function _isUint8Array(obj) {
-  return Buffer.isBuffer(obj) || typeof obj !== 'string' && obj instanceof OurUint8Array;
+  return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
 }
 /*</replacement>*/
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/readable-stream/issues/302

This is a partial fix.

Node 6.11, using readable-stream 2.2.11:

```
benchThrough2*10000: 5148.149ms
```

Node 6.11, using readable-stream 2.3.2:
```
benchThrough2*10000: 18112.640ms
```

Node 6.11, using this patch:

```
benchThrough2*10000: 6491.796ms
```

I think we can do better.

cc @bmeurer