### PR TITLE
Add nodejs supported version in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "stream",
     "pipe"
   ],
+  "engines": {
+    "node": ">=0.8"
+  },
   "browser": {
     "util": false,
     "./readable.js": "./readable-browser.js",


### PR DESCRIPTION
The `.travis.yml` describes the nodejs supported version.
This is not reflected in `package.json`.

(https://docs.npmjs.com/files/package.json#engines)