### PR TITLE
Don't add the Array.prototype.forEach replacement to files that don't use forEach.

### DIFF
--- a/build/files.js
+++ b/build/files.js
@@ -36,8 +36,6 @@ const headRegexp = /(^module.exports = \w+;?)/m
         , '\n$1\n  Duplex = Duplex || require(\'./_stream_duplex\');\n'
       ]
 
-    , altForEachImplReplacement = require('./common-replacements').altForEachImplReplacement
-    , altForEachUseReplacement  = require('./common-replacements').altForEachUseReplacement
     , altIndexOfImplReplacement = require('./common-replacements').altIndexOfImplReplacement
     , altIndexOfUseReplacement  = require('./common-replacements').altIndexOfUseReplacement
 
@@ -238,8 +236,6 @@ module.exports['_stream_duplex.js'] = [
   , instanceofReplacement
   , utilReplacement
   , stringDecoderReplacement
-  , altForEachImplReplacement
-  , altForEachUseReplacement
   , objectKeysReplacement
   , objectKeysDefine
   , processNextTickImport
@@ -258,11 +254,8 @@ module.exports['_stream_readable.js'] = [
   , addDuplexDec
   , requireReplacement
   , instanceofReplacement
-  , altForEachImplReplacement
-  , altForEachUseReplacement
   , altIndexOfImplReplacement
   , altIndexOfUseReplacement
-  , instanceofReplacement
   , stringDecoderReplacement
   , isArrayReplacement
   , isArrayDefine

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -116,9 +116,3 @@ Duplex.prototype._destroy = function (err, cb) {
 
   pna.nextTick(cb, err);
 };
-
-function forEach(xs, f) {
-  for (var i = 0, l = xs.length; i < l; i++) {
-    f(xs[i], i);
-  }
-}

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1001,12 +1001,6 @@ function endReadableNT(state, stream) {
   }
 }
 
-function forEach(xs, f) {
-  for (var i = 0, l = xs.length; i < l; i++) {
-    f(xs[i], i);
-  }
-}
-
 function indexOf(xs, x) {
   for (var i = 0, l = xs.length; i < l; i++) {
     if (xs[i] === x) return i;


### PR DESCRIPTION
Saves a few bytes when used in a browser.