### PR TITLE
.npmignore: "docs/" => "doc/" to match real name

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,4 @@ zlib.js
 .zuul.yml
 .nyc_output
 coverage
-docs/
+doc/


### PR DESCRIPTION
Today I discovered 214 copies of this project's `doc/wg-meetings/2015-01-30.md` file on my dev machine :| Looks like a minor typo in .npmignore allowed the contents of `doc/` to be published with every version since [November 10, 2016](https://github.com/nodejs/readable-stream/commit/80dc00cb05335c5fbadf50a81650cba295a0e3b5#diff-0fd4ef892d9d4990033701887c2f9bcc) 

![screenshot 2018-06-14 11 56 20](https://user-images.githubusercontent.com/27985/41423712-09184d4a-6fca-11e8-90e8-8ed246bc316f.png)


For what it's worth, I've done this more times than I can remember <3