### PR TITLE
Add node >= 6 to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.0.2",
   "description": "Streams3, a user-land copy of the stream library from Node.js",
   "main": "readable.js",
+  "engines": {
+    "node": ">= 6"
+  },
   "dependencies": {
     "inherits": "^2.0.3",
     "string_decoder": "^1.1.1",


### PR DESCRIPTION
Hi ! I noticed that in 3.x

> v3.x.x of readable-stream supports Node 6, 8, and 10, ...

I added this to the `package.json` so automated tools that determine this requirement.