### PR TITLE
Fix errors in IE11

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -354,7 +354,8 @@ function computeNewHighWaterMark(n) {
 function howMuchToRead(n, state) {
   if (n <= 0 || state.length === 0 && state.ended) return 0;
   if (state.objectMode) return 1;
-  if (Number.isNaN(n)) {
+  // Equivalent to `if (Number.isNaN(n))` but works in IE11
+  if (n !== n) {
     // Only flow one buffer at a time
     if (state.flowing && state.length) return state.buffer.head.data.length;else return state.length;
   }
@@ -941,11 +942,14 @@ Readable.prototype.wrap = function (stream) {
   return this;
 };
 
-Readable.prototype[Symbol.asyncIterator] = function () {
-  emitExperimentalWarning('Readable[Symbol.asyncIterator]');
-  if (ReadableAsyncIterator === undefined) ReadableAsyncIterator = require('./internal/streams/async_iterator');
-  return new ReadableAsyncIterator(this);
-};
+// Only add asyncIterator if Symbol is available
+if (typeof Symbol === 'function') {
+  Readable.prototype[Symbol.asyncIterator] = function () {
+    emitExperimentalWarning('Readable[Symbol.asyncIterator]');
+    if (ReadableAsyncIterator === undefined) ReadableAsyncIterator = require('./internal/streams/async_iterator');
+    return new ReadableAsyncIterator(this);
+  };
+}
 
 Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
   // making it explicit this property is not enumerable


### PR DESCRIPTION
* Polyfill Number.isNaN
* Don't create Symbol.asyncIterator if Symbol is not defined

Fixes #364