### PR TITLE
Emit no experimental warning in browser.

### DIFF
--- a/experimentalWarning.js
+++ b/experimentalWarning.js
@@ -10,4 +10,8 @@ function emitExperimentalWarning(feature) {
   process.emitWarning(msg, 'ExperimentalWarning');
 }
 
-module.exports.emitExperimentalWarning = emitExperimentalWarning;
+function noop() {}
+
+module.exports.emitExperimentalWarning = process.emitWarning
+  ? emitExperimentalWarning
+  : noop;


### PR DESCRIPTION
Mostly just see this as a temporary solution until browser-process polyfill the `process.emitWarning`

closes #361 
