### PR TITLE
Use @babel/preset-env exclusively

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,23 @@
+{
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": [
+        "last 2 versions",
+        "not dead",
+        "node 6.0"
+      ],
+      "modules": "commonjs",
+      "exclude": [
+        "transform-regenerator",
+        "transform-typeof-symbol"
+      ],
+      "debug": true
+    }]
+  ],
+  "plugins": [
+    // Included in the preset, but we can't specify per-plugin options there
+    ["@babel/plugin-transform-classes", {
+      "loose": true
+    }]
+  ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ fs.js
 zlib.js
 .airtap.yml
 .airtaprc
+.babelrc
 .travis.yml
 .nyc_output
 coverage

--- a/build/build.js
+++ b/build/build.js
@@ -179,7 +179,7 @@ pump(
       list.forEach(function (file) {
         file = path.basename(file)
         processFile(
-            path.join(testsrcurl.replace(/parallel\/$/, 'common/'), file)
+            path.join(testsrcurl.replace(/parallel[/\\]$/, 'common/'), file)
           , path.join(testourroot.replace('parallel', 'common'), file)
           , testReplace['common.js']
         )

--- a/build/build.js
+++ b/build/build.js
@@ -62,23 +62,8 @@ function processFile (inputLoc, out, replacements, addAtEnd) {
     if (inputLoc.slice(-3) === '.js') {
       try {
         const transformed = babel.transform(data, {
-          plugins: [
-            '@babel/plugin-transform-parameters',
-            '@babel/plugin-transform-arrow-functions',
-            '@babel/plugin-proposal-object-rest-spread',
-            '@babel/plugin-transform-block-scoping',
-            '@babel/plugin-transform-template-literals',
-            '@babel/plugin-transform-shorthand-properties',
-            '@babel/plugin-transform-for-of',
-            ['@babel/transform-classes', { loose: true }],
-            '@babel/plugin-transform-destructuring',
-            '@babel/plugin-transform-computed-properties',
-            '@babel/plugin-transform-spread',
-            '@babel/plugin-proposal-optional-catch-binding',
-            '@babel/plugin-transform-modules-commonjs',
-            '@babel/plugin-transform-async-to-generator',
-            '@babel/plugin-proposal-async-generator-functions'
-          ]
+          // Required for babel to pick up .babelrc
+          filename: inputLoc
         })
         data = transformed.code
       } catch (err) {

--- a/errors-browser.js
+++ b/errors-browser.js
@@ -1,18 +1,6 @@
 'use strict';
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
 
 var codes = {};
 
@@ -32,12 +20,10 @@ function createErrorType(code, message, Base) {
   var NodeError =
   /*#__PURE__*/
   function (_Base) {
-    _inherits(NodeError, _Base);
+    _inheritsLoose(NodeError, _Base);
 
     function NodeError(arg1, arg2, arg3) {
-      _classCallCheck(this, NodeError);
-
-      return _possibleConstructorReturn(this, _getPrototypeOf(NodeError).call(this, getMessage(arg1, arg2, arg3)));
+      return _Base.call(this, getMessage(arg1, arg2, arg3)) || this;
     }
 
     return NodeError;
@@ -119,7 +105,7 @@ createErrorType('ERR_INVALID_ARG_TYPE', function (name, expected, actual) {
     msg = "The \"".concat(name, "\" ").concat(type, " ").concat(determiner, " ").concat(oneOf(expected, 'type'));
   }
 
-  msg += ". Received type ".concat(_typeof(actual));
+  msg += ". Received type ".concat(typeof actual);
   return msg;
 }, TypeError);
 createErrorType('ERR_STREAM_PUSH_AFTER_EOF', 'stream.push() after EOF');

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -77,7 +77,7 @@ Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._writableState.highWaterMark;
   }
 });
@@ -86,7 +86,7 @@ Object.defineProperty(Duplex.prototype, 'writableBuffer', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._writableState && this._writableState.getBuffer();
   }
 });
@@ -95,7 +95,7 @@ Object.defineProperty(Duplex.prototype, 'writableLength', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._writableState.length;
   }
 }); // the no-half-open enforcer
@@ -117,14 +117,14 @@ Object.defineProperty(Duplex.prototype, 'destroyed', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     if (this._readableState === undefined || this._writableState === undefined) {
       return false;
     }
 
     return this._readableState.destroyed && this._writableState.destroyed;
   },
-  set: function (value) {
+  set: function set(value) {
     // we ignore the value if the stream
     // has not been initialized yet
     if (this._readableState === undefined || this._writableState === undefined) {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -31,7 +31,7 @@ Readable.ReadableState = ReadableState;
 
 var EE = require('events').EventEmitter;
 
-var EElistenerCount = function (emitter, type) {
+var EElistenerCount = function EElistenerCount(emitter, type) {
   return emitter.listeners(type).length;
 };
 /*</replacement>*/
@@ -64,7 +64,7 @@ var debug;
 if (debugUtil && debugUtil.debuglog) {
   debug = debugUtil.debuglog('stream');
 } else {
-  debug = function () {};
+  debug = function debug() {};
 }
 /*</replacement>*/
 
@@ -187,14 +187,14 @@ Object.defineProperty(Readable.prototype, 'destroyed', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     if (this._readableState === undefined) {
       return false;
     }
 
     return this._readableState.destroyed;
   },
-  set: function (value) {
+  set: function set(value) {
     // we ignore the value if the stream
     // has not been initialized yet
     if (!this._readableState) {
@@ -971,7 +971,7 @@ Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._readableState.highWaterMark;
   }
 });
@@ -980,7 +980,7 @@ Object.defineProperty(Readable.prototype, 'readableBuffer', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._readableState && this._readableState.buffer;
   }
 });
@@ -989,10 +989,10 @@ Object.defineProperty(Readable.prototype, 'readableFlowing', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._readableState.flowing;
   },
-  set: function (state) {
+  set: function set(state) {
     if (this._readableState) {
       this._readableState.flowing = state;
     }
@@ -1005,7 +1005,7 @@ Object.defineProperty(Readable.prototype, 'readableLength', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._readableState.length;
   }
 }); // Pluck off n bytes from an array of buffers.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -210,14 +210,14 @@ var realHasInstance;
 if (typeof Symbol === 'function' && Symbol.hasInstance && typeof Function.prototype[Symbol.hasInstance] === 'function') {
   realHasInstance = Function.prototype[Symbol.hasInstance];
   Object.defineProperty(Writable, Symbol.hasInstance, {
-    value: function (object) {
+    value: function value(object) {
       if (realHasInstance.call(this, object)) return true;
       if (this !== Writable) return false;
       return object && object._writableState instanceof WritableState;
     }
   });
 } else {
-  realHasInstance = function (object) {
+  realHasInstance = function realHasInstance(object) {
     return object instanceof this;
   };
 }
@@ -331,7 +331,7 @@ Object.defineProperty(Writable.prototype, 'writableBuffer', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._writableState && this._writableState.getBuffer();
   }
 });
@@ -349,7 +349,7 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._writableState.highWaterMark;
   }
 }); // if we're already writing something, then just put this
@@ -573,7 +573,7 @@ Object.defineProperty(Writable.prototype, 'writableLength', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     return this._writableState.length;
   }
 });
@@ -656,14 +656,14 @@ Object.defineProperty(Writable.prototype, 'destroyed', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function () {
+  get: function get() {
     if (this._writableState === undefined) {
       return false;
     }
 
     return this._writableState.destroyed;
   },
-  set: function (value) {
+  set: function set(value) {
     // we ignore the value if the stream
     // has not been initialized yet
     if (!this._writableState) {

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -58,7 +58,7 @@ var ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf((_Object$setPro
     return this[kStream];
   },
 
-  next: function () {
+  next: function next() {
     var _this = this;
 
     // if we have detected an error in the meanwhile
@@ -115,7 +115,7 @@ var ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf((_Object$setPro
   }
 }, _defineProperty(_Object$setPrototypeO, Symbol.asyncIterator, function () {
   return this;
-}), _defineProperty(_Object$setPrototypeO, "return", function () {
+}), _defineProperty(_Object$setPrototypeO, "return", function _return() {
   var _this2 = this;
 
   // destroy(err, cb) is a private API
@@ -133,7 +133,7 @@ var ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf((_Object$setPro
   });
 }), _Object$setPrototypeO), AsyncIteratorPrototype);
 
-var createReadableStreamAsyncIterator = function (stream) {
+var createReadableStreamAsyncIterator = function createReadableStreamAsyncIterator(stream) {
   var _Object$create;
 
   var iterator = Object.create(ReadableStreamAsyncIteratorPrototype, (_Object$create = {}, _defineProperty(_Object$create, kStream, {
@@ -155,7 +155,7 @@ var createReadableStreamAsyncIterator = function (stream) {
     value: null,
     writable: true
   }), _defineProperty(_Object$create, kHandlePromise, {
-    value: function (resolve, reject) {
+    value: function value(resolve, reject) {
       var data = iterator[kStream].read();
 
       if (data) {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -28,25 +28,25 @@ function eos(stream, opts, callback) {
   var readable = opts.readable || opts.readable !== false && stream.readable;
   var writable = opts.writable || opts.writable !== false && stream.writable;
 
-  var onlegacyfinish = function () {
+  var onlegacyfinish = function onlegacyfinish() {
     if (!stream.writable) onfinish();
   };
 
-  var onfinish = function () {
+  var onfinish = function onfinish() {
     writable = false;
     if (!readable) callback.call(stream);
   };
 
-  var onend = function () {
+  var onend = function onend() {
     readable = false;
     if (!writable) callback.call(stream);
   };
 
-  var onerror = function (err) {
+  var onerror = function onerror(err) {
     callback.call(stream, err);
   };
 
-  var onclose = function () {
+  var onclose = function onclose() {
     if (readable && !(rs && rs.ended)) {
       return callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
     }
@@ -56,7 +56,7 @@ function eos(stream, opts, callback) {
     }
   };
 
-  var onrequest = function () {
+  var onrequest = function onrequest() {
     stream.req.on('finish', onfinish);
   };
 

--- a/package.json
+++ b/package.json
@@ -14,20 +14,6 @@
   "devDependencies": {
     "@babel/cli": "^7.2.0",
     "@babel/core": "^7.2.0",
-    "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-    "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
-    "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-    "@babel/plugin-transform-arrow-functions": "^7.2.0",
-    "@babel/plugin-transform-async-to-generator": "^7.2.0",
-    "@babel/plugin-transform-block-scoping": "^7.2.0",
-    "@babel/plugin-transform-classes": "^7.2.2",
-    "@babel/plugin-transform-computed-properties": "^7.2.0",
-    "@babel/plugin-transform-destructuring": "^7.2.0",
-    "@babel/plugin-transform-for-of": "^7.2.0",
-    "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-    "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-    "@babel/plugin-transform-spread": "^7.2.0",
-    "@babel/plugin-transform-template-literals": "^7.2.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.2.0",
     "airtap": "0.0.9",
@@ -53,7 +39,7 @@
     "test-browser-local": "airtap --open --local -- test/browser.js",
     "cover": "nyc npm test",
     "report": "nyc report --reporter=lcov",
-    "update-browser-errors": "babel --presets @babel/env -o errors-browser.js errors.js"
+    "update-browser-errors": "babel -o errors-browser.js errors.js"
   },
   "repository": {
     "type": "git",

--- a/test/common/countdown.js
+++ b/test/common/countdown.js
@@ -60,7 +60,7 @@ function () {
 
   _createClass(Countdown, [{
     key: "remaining",
-    get: function () {
+    get: function get() {
       return this[kLimit];
     }
   }]);

--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -222,12 +222,12 @@ function writeIPv6(ip) {
 
   try {
     for (var _iterator = parts[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-      var _part = _step.value;
+      var part = _step.value;
 
-      if (_part === '') {
+      if (part === '') {
         offset += 16 - 2 * (parts.length - 1);
       } else {
-        buf.writeUInt16BE(parseInt(_part, 16), offset);
+        buf.writeUInt16BE(parseInt(part, 16), offset);
         offset += 2;
       }
     }
@@ -266,10 +266,10 @@ function writeDNSPacket(parsed) {
 
   try {
     for (var _iterator2 = parsed.questions[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-      var _q = _step2.value;
-      assert(types[_q.type]);
-      buffers.push(writeDomainName(_q.domain));
-      buffers.push(new Uint16Array([types[_q.type], _q.cls === undefined ? classes.IN : _q.cls]));
+      var q = _step2.value;
+      assert(types[q.type]);
+      buffers.push(writeDomainName(q.domain));
+      buffers.push(new Uint16Array([types[q.type], q.cls === undefined ? classes.IN : q.cls]));
     }
   } catch (err) {
     _didIteratorError2 = true;
@@ -292,44 +292,43 @@ function writeDNSPacket(parsed) {
 
   try {
     for (var _iterator3 = [].concat(parsed.answers, parsed.authorityAnswers, parsed.additionalRecords)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-      var _rr = _step3.value;
-      if (!_rr) continue;
-      assert(types[_rr.type]);
-      buffers.push(writeDomainName(_rr.domain));
-      buffers.push(new Uint16Array([types[_rr.type], _rr.cls === undefined ? classes.IN : _rr.cls]));
-      buffers.push(new Int32Array([_rr.ttl]));
+      var rr = _step3.value;
+      if (!rr) continue;
+      assert(types[rr.type]);
+      buffers.push(writeDomainName(rr.domain));
+      buffers.push(new Uint16Array([types[rr.type], rr.cls === undefined ? classes.IN : rr.cls]));
+      buffers.push(new Int32Array([rr.ttl]));
       var rdLengthBuf = new Uint16Array(1);
       buffers.push(rdLengthBuf);
 
-      switch (_rr.type) {
+      switch (rr.type) {
         case 'A':
           rdLengthBuf[0] = 4;
-          buffers.push(new Uint8Array(_rr.address.split('.')));
+          buffers.push(new Uint8Array(rr.address.split('.')));
           break;
 
         case 'AAAA':
           rdLengthBuf[0] = 16;
-          buffers.push(writeIPv6(_rr.address));
+          buffers.push(writeIPv6(rr.address));
           break;
 
         case 'TXT':
-          var total = _rr.entries.map(function (s) {
+          var total = rr.entries.map(function (s) {
             return s.length;
           }).reduce(function (a, b) {
             return a + b;
           }); // Total length of all strings + 1 byte each for their lengths.
 
-
-          rdLengthBuf[0] = _rr.entries.length + total;
+          rdLengthBuf[0] = rr.entries.length + total;
           var _iteratorNormalCompletion4 = true;
           var _didIteratorError4 = false;
           var _iteratorError4 = undefined;
 
           try {
-            for (var _iterator4 = _rr.entries[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-              var _txt = _step4.value;
-              buffers.push(new Uint8Array([Buffer.byteLength(_txt)]));
-              buffers.push(Buffer.from(_txt));
+            for (var _iterator4 = rr.entries[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+              var txt = _step4.value;
+              buffers.push(new Uint8Array([Buffer.byteLength(txt)]));
+              buffers.push(Buffer.from(txt));
             }
           } catch (err) {
             _didIteratorError4 = true;
@@ -350,14 +349,14 @@ function writeDNSPacket(parsed) {
 
         case 'MX':
           rdLengthBuf[0] = 2;
-          buffers.push(new Uint16Array([_rr.priority]));
+          buffers.push(new Uint16Array([rr.priority]));
         // fall through
 
         case 'NS':
         case 'CNAME':
         case 'PTR':
           {
-            var domain = writeDomainName(_rr.exchange || _rr.value);
+            var domain = writeDomainName(rr.exchange || rr.value);
             rdLengthBuf[0] += domain.length;
             buffers.push(domain);
             break;
@@ -365,16 +364,16 @@ function writeDNSPacket(parsed) {
 
         case 'SOA':
           {
-            var mname = writeDomainName(_rr.nsname);
-            var rname = writeDomainName(_rr.hostmaster);
+            var mname = writeDomainName(rr.nsname);
+            var rname = writeDomainName(rr.hostmaster);
             rdLengthBuf[0] = mname.length + rname.length + 20;
             buffers.push(mname, rname);
-            buffers.push(new Uint32Array([_rr.serial, _rr.refresh, _rr.retry, _rr.expire, _rr.minttl]));
+            buffers.push(new Uint32Array([rr.serial, rr.refresh, rr.retry, rr.expire, rr.minttl]));
             break;
           }
 
         default:
-          throw new Error("Unknown RR type ".concat(_rr.type));
+          throw new Error("Unknown RR type ".concat(rr.type));
       }
     }
   } catch (err) {

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -111,33 +111,32 @@ function () {
 
     try {
       for (var _iterator = expected[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-        var _expectation = _step.value;
+        var expectation = _step.value;
 
-        if (_expectation.children) {
-          var _loop = function (expectedEdge) {
-            var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
-              return isEdge(edge, expectedEdge);
-            };
-            var hasChild = rootNodes.some(function (node) {
-              return node.outgoingEdges.some(check);
-            }); // Don't use assert with a custom message here. Otherwise the
-            // inspection in the message is done eagerly and wastes a lot of CPU
-            // time.
-
-            if (!hasChild) {
-              throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
-            }
-          };
-
+        if (expectation.children) {
           var _iteratorNormalCompletion2 = true;
           var _didIteratorError2 = false;
           var _iteratorError2 = undefined;
 
           try {
-            for (var _iterator2 = _expectation.children[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var _loop = function _loop() {
               var expectedEdge = _step2.value;
+              var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
+                return isEdge(edge, expectedEdge);
+              };
+              var hasChild = rootNodes.some(function (node) {
+                return node.outgoingEdges.some(check);
+              }); // Don't use assert with a custom message here. Otherwise the
+              // inspection in the message is done eagerly and wastes a lot of CPU
+              // time.
 
-              _loop(expectedEdge);
+              if (!hasChild) {
+                throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
+              }
+            };
+
+            for (var _iterator2 = expectation.children[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+              _loop();
             }
           } catch (err) {
             _didIteratorError2 = true;
@@ -193,34 +192,33 @@ function () {
 
     try {
       for (var _iterator3 = expected[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-        var _expectation2 = _step3.value;
+        var expectation = _step3.value;
 
-        if (_expectation2.children) {
-          var _loop2 = function (expectedEdge) {
-            var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
-              return isEdge(edge, expectedEdge);
-            }; // Don't use assert with a custom message here. Otherwise the
-            // inspection in the message is done eagerly and wastes a lot of CPU
-            // time.
-
-            var hasChild = rootNodes.some(function (node) {
-              return node.edges.some(check);
-            });
-
-            if (!hasChild) {
-              throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
-            }
-          };
-
+        if (expectation.children) {
           var _iteratorNormalCompletion4 = true;
           var _didIteratorError4 = false;
           var _iteratorError4 = undefined;
 
           try {
-            for (var _iterator4 = _expectation2.children[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+            var _loop2 = function _loop2() {
               var expectedEdge = _step4.value;
+              var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
+                return isEdge(edge, expectedEdge);
+              }; // Don't use assert with a custom message here. Otherwise the
+              // inspection in the message is done eagerly and wastes a lot of CPU
+              // time.
 
-              _loop2(expectedEdge);
+              var hasChild = rootNodes.some(function (node) {
+                return node.edges.some(check);
+              });
+
+              if (!hasChild) {
+                throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
+              }
+            };
+
+            for (var _iterator4 = expectation.children[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+              _loop2();
             }
           } catch (err) {
             _didIteratorError4 = true;

--- a/test/common/http2.js
+++ b/test/common/http2.js
@@ -92,7 +92,7 @@ function () {
 
   _createClass(Frame, [{
     key: "data",
-    get: function () {
+    get: function get() {
       return this[kFrameData];
     }
   }]);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -82,7 +82,7 @@ util.inherits = require('inherits');
 /*</replacement>*/
 
 var Timer = {
-  now: function () {}
+  now: function now() {}
 };
 
 var tmpdir = require('./tmpdir');
@@ -91,7 +91,7 @@ var _process$binding = process.binding('config'),
     bits = _process$binding.bits,
     hasIntl = _process$binding.hasIntl;
 
-var noop = function () {};
+var noop = function noop() {};
 
 var isMainThread = function () {
   try {
@@ -556,8 +556,8 @@ var Comparison = function Comparison(obj, keys) {
 
   try {
     for (var _iterator = keys[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-      var _key2 = _step.value;
-      if (_key2 in obj) this[_key2] = obj[_key2];
+      var key = _step.value;
+      if (key in obj) this[key] = obj[key];
     }
   } catch (err) {
     _didIteratorError = true;
@@ -627,9 +627,9 @@ function expectsError(fn, settings, exact) {
 
     try {
       for (var _iterator2 = keys[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-        var _key3 = _step2.value;
+        var key = _step2.value;
 
-        if (!require('deep-strict-equal')(error[_key3], innerSettings[_key3])) {
+        if (!require('deep-strict-equal')(error[key], innerSettings[key])) {
           // Create placeholder objects to create a nice output.
           var a = new Comparison(error, keys);
           var b = new Comparison(innerSettings, keys);
@@ -719,7 +719,7 @@ function getBufferSources(buf) {
 } // Crash the process on unhandled rejections.
 
 
-var crashOnUnhandledRejection = function (err) {
+var crashOnUnhandledRejection = function crashOnUnhandledRejection(err) {
   throw err;
 };
 

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -92,8 +92,8 @@ function makeBufferingDataCallback(dataCallback) {
 
     try {
       for (var _iterator = lines[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-        var _line = _step.value;
-        dataCallback(_line);
+        var line = _step.value;
+        dataCallback(line);
       }
     } catch (err) {
       _didIteratorError = true;
@@ -405,8 +405,8 @@ function () {
 
         try {
           for (var _iterator2 = params.args[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-            var _value = _step2.value;
-            if (_value.value !== values[_i2++]) return false;
+            var value = _step2.value;
+            if (value.value !== values[_i2++]) return false;
           }
         } catch (err) {
           _didIteratorError2 = true;
@@ -724,7 +724,7 @@ function timeoutPromise(error, timeoutMs) {
       return reject(error);
     }, timeoutMs);
 
-    clearCallback = function () {
+    clearCallback = function clearCallback() {
       if (done) return;
       clearTimeout(timeout);
       resolve();

--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -74,11 +74,11 @@ var _iteratorError = undefined;
 
 try {
   for (var _iterator = objectKeys(addresses)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-    var _key = _step.value;
-    var envName = "NODE_TEST_".concat(_key);
+    var key = _step.value;
+    var envName = "NODE_TEST_".concat(key);
 
     if (process.env[envName]) {
-      addresses[_key] = process.env[envName];
+      addresses[key] = process.env[envName];
     }
   }
 } catch (err) {

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -33,7 +33,7 @@ var assert = require('assert'); // https://github.com/w3c/testharness.js/blob/ma
 
 
 module.exports = {
-  test: function (fn, desc) {
+  test: function test(fn, desc) {
     try {
       fn();
     } catch (err) {
@@ -42,19 +42,19 @@ module.exports = {
     }
   },
   assert_equals: assert.strictEqual,
-  assert_true: function (value, message) {
+  assert_true: function assert_true(value, message) {
     return assert.strictEqual(value, true, message);
   },
-  assert_false: function (value, message) {
+  assert_false: function assert_false(value, message) {
     return assert.strictEqual(value, false, message);
   },
-  assert_throws: function (code, func, desc) {
+  assert_throws: function assert_throws(code, func, desc) {
     assert.throws(func, function (err) {
       return typeof err === 'object' && 'name' in err && err.name.startsWith(code.name);
     }, desc);
   },
   assert_array_equals: assert.deepStrictEqual,
-  assert_unreached: function (desc) {
+  assert_unreached: function assert_unreached(desc) {
     assert.fail("Reached unreachable code: ".concat(desc));
   }
 };

--- a/test/parallel/test-stream-decoder-objectmode.js
+++ b/test/parallel/test-stream-decoder-objectmode.js
@@ -12,7 +12,7 @@ var stream = require('../../');
 var assert = require('assert/');
 
 var readable = new stream.Readable({
-  read: function () {},
+  read: function read() {},
   encoding: 'utf16le',
   objectMode: true
 });

--- a/test/parallel/test-stream-destroy-event-order.js
+++ b/test/parallel/test-stream-destroy-event-order.js
@@ -13,7 +13,7 @@ var _require = require('../../'),
     Readable = _require.Readable;
 
 var rs = new Readable({
-  read: function () {}
+  read: function read() {}
 });
 var closed = false;
 var errored = false;

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -17,10 +17,10 @@ var _require2 = require('util'),
 
 {
   var duplex = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {}
+    read: function read() {}
   });
   duplex.resume();
   duplex.on('end', common.mustNotCall());
@@ -31,10 +31,10 @@ var _require2 = require('util'),
 }
 {
   var _duplex = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {}
+    read: function read() {}
   });
 
   _duplex.resume();
@@ -55,10 +55,10 @@ var _require2 = require('util'),
 }
 {
   var _duplex2 = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {}
+    read: function read() {}
   });
 
   _duplex2._destroy = common.mustCall(function (err, cb) {
@@ -82,10 +82,10 @@ var _require2 = require('util'),
   var _expected2 = new Error('kaboom');
 
   var _duplex3 = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {},
+    read: function read() {},
     destroy: common.mustCall(function (err, cb) {
       assert.strictEqual(err, _expected2);
       cb();
@@ -109,10 +109,10 @@ var _require2 = require('util'),
 }
 {
   var _duplex4 = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {}
+    read: function read() {}
   });
 
   _duplex4._destroy = common.mustCall(function (err, cb) {
@@ -126,10 +126,10 @@ var _require2 = require('util'),
 }
 {
   var _duplex5 = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {}
+    read: function read() {}
   });
 
   _duplex5.resume();
@@ -166,10 +166,10 @@ var _require2 = require('util'),
 }
 {
   var _duplex6 = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {}
+    read: function read() {}
   });
 
   var _expected3 = new Error('kaboom');
@@ -193,10 +193,10 @@ var _require2 = require('util'),
 }
 {
   var _duplex7 = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {},
+    read: function read() {},
     allowHalfOpen: true
   });
 
@@ -212,10 +212,10 @@ var _require2 = require('util'),
 }
 {
   var _duplex8 = new Duplex({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
-    read: function () {}
+    read: function read() {}
   });
 
   _duplex8.destroyed = true;
@@ -228,11 +228,11 @@ var _require2 = require('util'),
   _duplex8.destroy();
 }
 {
-  function MyDuplex() {
+  var MyDuplex = function MyDuplex() {
     assert.strictEqual(this.destroyed, false);
     this.destroyed = false;
     Duplex.call(this);
-  }
+  };
 
   inherits(MyDuplex, Duplex);
   new MyDuplex();

--- a/test/parallel/test-stream-duplex-end.js
+++ b/test/parallel/test-stream-duplex-end.js
@@ -13,7 +13,7 @@ var Duplex = require('../../').Duplex;
 
 {
   var stream = new Duplex({
-    read: function () {}
+    read: function read() {}
   });
   assert.strictEqual(stream.allowHalfOpen, true);
   stream.on('finish', common.mustNotCall());
@@ -23,7 +23,7 @@ var Duplex = require('../../').Duplex;
 }
 {
   var _stream = new Duplex({
-    read: function () {},
+    read: function read() {},
     allowHalfOpen: false
   });
 
@@ -39,7 +39,7 @@ var Duplex = require('../../').Duplex;
 }
 {
   var _stream2 = new Duplex({
-    read: function () {},
+    read: function read() {},
     allowHalfOpen: false
   });
 

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -25,7 +25,7 @@ var promisify = require('util-promisify');
 
 {
   var rs = new Readable({
-    read: function () {}
+    read: function read() {}
   });
   finished(rs, common.mustCall(function (err) {
     assert(!err, 'no error');
@@ -35,7 +35,7 @@ var promisify = require('util-promisify');
 }
 {
   var ws = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       cb();
     }
   });
@@ -46,7 +46,7 @@ var promisify = require('util-promisify');
 }
 {
   var tr = new Transform({
-    transform: function (data, enc, cb) {
+    transform: function transform(data, enc, cb) {
       cb();
     }
   });
@@ -74,14 +74,10 @@ var promisify = require('util-promisify');
   finished(_rs, common.mustCall());
 }
 {
-  var finishedPromise = promisify(finished);
-
-  function run() {
-    return _run.apply(this, arguments);
-  }
-
-  function _run() {
-    _run = _asyncToGenerator(function* () {
+  var run =
+  /*#__PURE__*/
+  function () {
+    var _ref = _asyncToGenerator(function* () {
       var rs = fs.createReadStream(__filename);
       var done = common.mustCall();
       var ended = false;
@@ -93,9 +89,13 @@ var promisify = require('util-promisify');
       assert(ended);
       done();
     });
-    return _run.apply(this, arguments);
-  }
 
+    return function run() {
+      return _ref.apply(this, arguments);
+    };
+  }();
+
+  var finishedPromise = promisify(finished);
   run();
 }
 {
@@ -136,7 +136,7 @@ var promisify = require('util-promisify');
 
 {
   var _ws = new Writable({
-    write: function (data, env, cb) {
+    write: function write(data, env, cb) {
       cb();
     }
   });

--- a/test/parallel/test-stream-once-readable-pipe.js
+++ b/test/parallel/test-stream-once-readable-pipe.js
@@ -18,14 +18,14 @@ var _require = require('../../'),
 {
   var receivedData = '';
   var w = new Writable({
-    write: function (chunk, env, callback) {
+    write: function write(chunk, env, callback) {
       receivedData += chunk;
       callback();
     }
   });
   var data = ['foo', 'bar', 'baz'];
   var r = new Readable({
-    read: function () {}
+    read: function read() {}
   });
   r.once('readable', common.mustCall());
   r.pipe(w);
@@ -41,7 +41,7 @@ var _require = require('../../'),
   var _receivedData = '';
 
   var _w = new Writable({
-    write: function (chunk, env, callback) {
+    write: function write(chunk, env, callback) {
       _receivedData += chunk;
       callback();
     }
@@ -50,7 +50,7 @@ var _require = require('../../'),
   var _data = ['foo', 'bar', 'baz'];
 
   var _r = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _r.pipe(_w);

--- a/test/parallel/test-stream-pipe-await-drain-manual-resume.js
+++ b/test/parallel/test-stream-pipe-await-drain-manual-resume.js
@@ -28,7 +28,7 @@ writable._write = function (chunk, encoding, cb) {
 };
 
 var readable = new stream.Readable({
-  read: function () {}
+  read: function read() {}
 });
 readable.pipe(writable);
 readable.once('pause', common.mustCall(function () {

--- a/test/parallel/test-stream-pipe-await-drain-push-while-write.js
+++ b/test/parallel/test-stream-pipe-await-drain-push-while-write.js
@@ -33,7 +33,7 @@ var writable = new stream.Writable({
 var bufs = [bufferShim.alloc(32 * 1024), bufferShim.alloc(33 * 1024)]; // above hwm
 
 var readable = new stream.Readable({
-  read: function () {
+  read: function read() {
     while (bufs.length > 0) {
       this.push(bufs.shift());
     }

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -64,6 +64,10 @@ var Stream = require('stream').Stream;
   assert.strictEqual(_gotErr, _err);
 }
 {
+  var myOnError = function myOnError() {
+    throw new Error('this should not happen');
+  };
+
   var R = require('../../').Readable;
 
   var W = require('../../').Writable;
@@ -83,10 +87,6 @@ var Stream = require('stream').Stream;
   r.pipe(w);
   w.removeListener('error', myOnError);
   removed = true;
-
-  function myOnError() {
-    throw new Error('this should not happen');
-  }
 }
 {
   var _R = require('../../').Readable;

--- a/test/parallel/test-stream-pipe-flow.js
+++ b/test/parallel/test-stream-pipe-flow.js
@@ -16,7 +16,7 @@ var _require = require('../../'),
   var ticks = 17;
   var rs = new Readable({
     objectMode: true,
-    read: function () {
+    read: function read() {
       if (ticks-- > 0) return process.nextTick(function () {
         return rs.push({});
       });
@@ -27,7 +27,7 @@ var _require = require('../../'),
   var ws = new Writable({
     highWaterMark: 0,
     objectMode: true,
-    write: function (data, end, cb) {
+    write: function write(data, end, cb) {
       return setImmediate(cb);
     }
   });
@@ -40,7 +40,7 @@ var _require = require('../../'),
 
   var _rs = new Readable({
     objectMode: true,
-    read: function () {
+    read: function read() {
       if (missing--) _rs.push({});else _rs.push(null);
     }
   });
@@ -58,7 +58,7 @@ var _require = require('../../'),
   });
   var wrapper = new Readable({
     objectMode: true,
-    read: function () {
+    read: function read() {
       process.nextTick(function () {
         var data = pt.read();
 

--- a/test/parallel/test-stream-pipe-multiple-pipes.js
+++ b/test/parallel/test-stream-pipe-multiple-pipes.js
@@ -12,11 +12,11 @@ var stream = require('../../');
 var assert = require('assert/');
 
 var readable = new stream.Readable({
-  read: function () {}
+  read: function read() {}
 });
 var writables = [];
 
-var _loop = function (i) {
+var _loop = function _loop(i) {
   var target = new stream.Writable({
     write: common.mustCall(function (chunk, encoding, callback) {
       target.output.push(chunk);

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -14,13 +14,13 @@ var _require = require('../../'),
     Writable = _require.Writable;
 
 var source = Readable({
-  read: function () {}
+  read: function read() {}
 });
 var dest1 = Writable({
-  write: function () {}
+  write: function write() {}
 });
 var dest2 = Writable({
-  write: function () {}
+  write: function write() {}
 });
 source.pipe(dest1);
 source.pipe(dest2);
@@ -38,32 +38,7 @@ source.unpipe(dest2);
 source.unpipe(dest1);
 assert.strictEqual(source._readableState.pipes, null);
 {
-  // test `cleanup()` if we unpipe all streams.
-  var _source = Readable({
-    read: function () {}
-  });
-
-  var _dest = Writable({
-    write: function () {}
-  });
-
-  var _dest2 = Writable({
-    write: function () {}
-  });
-
-  var destCount = 0;
-  var srcCheckEventNames = ['end', 'data'];
-  var destCheckEventNames = ['close', 'finish', 'drain', 'error', 'unpipe'];
-  var checkSrcCleanup = common.mustCall(function () {
-    assert.strictEqual(_source._readableState.pipes, null);
-    assert.strictEqual(_source._readableState.pipesCount, 0);
-    assert.strictEqual(_source._readableState.flowing, false);
-    srcCheckEventNames.forEach(function (eventName) {
-      assert.strictEqual(_source.listenerCount(eventName), 0, "source's '".concat(eventName, "' event listeners not removed"));
-    });
-  });
-
-  function checkDestCleanup(dest) {
+  var checkDestCleanup = function checkDestCleanup(dest) {
     var currentDestId = ++destCount;
 
     _source.pipe(dest);
@@ -77,8 +52,32 @@ assert.strictEqual(source._readableState.pipes, null);
       if (--destCount === 0) checkSrcCleanup();
     });
     dest.on('unpipe', unpipeChecker);
-  }
+  };
 
+  // test `cleanup()` if we unpipe all streams.
+  var _source = Readable({
+    read: function read() {}
+  });
+
+  var _dest = Writable({
+    write: function write() {}
+  });
+
+  var _dest2 = Writable({
+    write: function write() {}
+  });
+
+  var destCount = 0;
+  var srcCheckEventNames = ['end', 'data'];
+  var destCheckEventNames = ['close', 'finish', 'drain', 'error', 'unpipe'];
+  var checkSrcCleanup = common.mustCall(function () {
+    assert.strictEqual(_source._readableState.pipes, null);
+    assert.strictEqual(_source._readableState.pipesCount, 0);
+    assert.strictEqual(_source._readableState.flowing, false);
+    srcCheckEventNames.forEach(function (eventName) {
+      assert.strictEqual(_source.listenerCount(eventName), 0, "source's '".concat(eventName, "' event listeners not removed"));
+    });
+  });
   checkDestCleanup(_dest);
   checkDestCleanup(_dest2);
 

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -25,9 +25,9 @@ var assert = require('assert/');
 var http = require('http');
 
 var http2 = {
-  createServer: function () {
+  createServer: function createServer() {
     return {
-      listen: function () {}
+      listen: function listen() {}
     };
   }
 };
@@ -39,10 +39,10 @@ var promisify = require('util-promisify');
   var processed = [];
   var expected = [bufferShim.from('a'), bufferShim.from('b'), bufferShim.from('c')];
   var read = new Readable({
-    read: function () {}
+    read: function read() {}
   });
   var write = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       processed.push(data);
       cb();
     }
@@ -64,7 +64,7 @@ var promisify = require('util-promisify');
 }
 {
   var _read = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   assert.throws(function () {
@@ -79,11 +79,11 @@ var promisify = require('util-promisify');
 }
 {
   var _read2 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   var _write = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       cb();
     }
   });
@@ -99,11 +99,11 @@ var promisify = require('util-promisify');
 }
 {
   var _read3 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   var _write2 = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       cb();
     }
   });
@@ -120,17 +120,17 @@ var promisify = require('util-promisify');
 }
 {
   var _read4 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   var transform = new Transform({
-    transform: function (data, enc, cb) {
+    transform: function transform(data, enc, cb) {
       process.nextTick(cb, new Error('kaboom'));
     }
   });
 
   var _write3 = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       cb();
     }
   });
@@ -152,7 +152,7 @@ var promisify = require('util-promisify');
 {
   var server = http.createServer(function (req, res) {
     var rs = new Readable({
-      read: function () {
+      read: function read() {
         rs.push('hello');
         rs.push(null);
       }
@@ -180,7 +180,7 @@ var promisify = require('util-promisify');
   var _server = http.createServer(function (req, res) {
     var sent = false;
     var rs = new Readable({
-      read: function () {
+      read: function read() {
         if (sent) {
           return;
         }
@@ -214,7 +214,7 @@ var promisify = require('util-promisify');
   var _server2 = http.createServer(function (req, res) {
     var sent = 0;
     var rs = new Readable({
-      read: function () {
+      read: function read() {
         if (sent++ > 10) {
           return;
         }
@@ -230,7 +230,7 @@ var promisify = require('util-promisify');
 
   var cnt = 10;
   var badSink = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       cnt--;
       if (cnt === 0) process.nextTick(cb, new Error('kaboom'));else cb();
     }
@@ -261,7 +261,7 @@ var promisify = require('util-promisify');
     });
     var sent = 0;
     var rs = new Readable({
-      read: function () {
+      read: function read() {
         if (sent++ > 10) {
           return;
         }
@@ -293,7 +293,7 @@ var promisify = require('util-promisify');
       ':method': 'POST'
     });
     var rs = new Readable({
-      read: function () {
+      read: function read() {
         rs.push('hello');
       }
     });
@@ -310,9 +310,9 @@ var promisify = require('util-promisify');
   });
 }
 {
-  var makeTransform = function () {
+  var makeTransform = function makeTransform() {
     var tr = new Transform({
-      transform: function (data, enc, cb) {
+      transform: function transform(data, enc, cb) {
         cb(null, data);
       }
     });
@@ -321,13 +321,13 @@ var promisify = require('util-promisify');
   };
 
   var rs = new Readable({
-    read: function () {
+    read: function read() {
       rs.push('hello');
     }
   });
   var _cnt = 10;
   var ws = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       _cnt--;
       if (_cnt === 0) return process.nextTick(cb, new Error('kaboom'));
       cb();
@@ -356,7 +356,7 @@ var promisify = require('util-promisify');
   var _expected = [bufferShim.from('hello'), bufferShim.from('world')];
 
   var _rs = new Readable({
-    read: function () {
+    read: function read() {
       for (var _i = 0; _i < _expected.length; _i++) {
         _rs.push(_expected[_i]);
       }
@@ -366,7 +366,7 @@ var promisify = require('util-promisify');
   });
 
   var _ws = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       assert.deepStrictEqual(data, _expected.shift());
       cb();
     }
@@ -416,13 +416,13 @@ var promisify = require('util-promisify');
   };
 
   var _rs2 = new Readable({
-    read: function () {
+    read: function read() {
       _rs2.destroy(new Error('stop'));
     }
   });
 
   var _ws2 = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       cb();
     }
   });
@@ -439,19 +439,15 @@ var promisify = require('util-promisify');
   }));
 }
 {
-  var pipelinePromise = promisify(pipeline);
-
-  function run() {
-    return _run.apply(this, arguments);
-  }
-
-  function _run() {
-    _run = _asyncToGenerator(function* () {
+  var run =
+  /*#__PURE__*/
+  function () {
+    var _ref = _asyncToGenerator(function* () {
       var read = new Readable({
-        read: function () {}
+        read: function read() {}
       });
       var write = new Writable({
-        write: function (data, enc, cb) {
+        write: function write(data, enc, cb) {
           cb();
         }
       });
@@ -464,24 +460,28 @@ var promisify = require('util-promisify');
       yield pipelinePromise(read, write);
       assert(finished);
     });
-    return _run.apply(this, arguments);
-  }
 
+    return function run() {
+      return _ref.apply(this, arguments);
+    };
+  }();
+
+  var pipelinePromise = promisify(pipeline);
   run();
 }
 {
   var _read5 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   var _transform = new Transform({
-    transform: function (data, enc, cb) {
+    transform: function transform(data, enc, cb) {
       process.nextTick(cb, new Error('kaboom'));
     }
   });
 
   var _write4 = new Writable({
-    write: function (data, enc, cb) {
+    write: function write(data, enc, cb) {
       cb();
     }
   });

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -35,7 +35,7 @@ function _tests() {
     yield _asyncToGenerator(function* () {
       var readable = new Readable({
         objectMode: true,
-        read: function () {}
+        read: function read() {}
       });
       readable.push(0);
       readable.push(1);
@@ -72,7 +72,7 @@ function _tests() {
       var max = 5;
       var readable = new Readable({
         objectMode: true,
-        read: function () {}
+        read: function read() {}
       });
       var iter = readable[Symbol.asyncIterator]();
       assert.strictEqual(iter.stream, readable);
@@ -100,7 +100,7 @@ function _tests() {
       console.log('read without for..await deferred');
       var readable = new Readable({
         objectMode: true,
-        read: function () {}
+        read: function read() {}
       });
       var iter = readable[Symbol.asyncIterator]();
       assert.strictEqual(iter.stream, readable);
@@ -139,7 +139,7 @@ function _tests() {
       var max = 3;
       var readable = new Readable({
         objectMode: true,
-        read: function () {}
+        read: function read() {}
       });
       var iter = readable[Symbol.asyncIterator]();
       assert.strictEqual(iter.stream, readable);
@@ -172,7 +172,7 @@ function _tests() {
     yield _asyncToGenerator(function* () {
       console.log('call next() after error');
       var readable = new Readable({
-        read: function () {}
+        read: function read() {}
       });
       var iterator = readable[Symbol.asyncIterator]();
       var err = new Error('kaboom');
@@ -198,7 +198,7 @@ function _tests() {
       var received = 0;
       var readable = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           this.push('hello');
 
           if (++readed === max) {
@@ -238,7 +238,7 @@ function _tests() {
       console.log('destroy sync');
       var readable = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           this.destroy(new Error('kaboom from read'));
         }
       });
@@ -279,7 +279,7 @@ function _tests() {
       console.log('destroy async');
       var readable = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           var _this = this;
 
           if (!this.pushed) {
@@ -331,7 +331,7 @@ function _tests() {
       console.log('destroyed by throw');
       var readable = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           this.push('hello');
         }
       });
@@ -374,7 +374,7 @@ function _tests() {
       console.log('destroyed sync after push');
       var readable = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           this.push('hello');
           this.destroy(new Error('kaboom'));
         }
@@ -422,7 +422,7 @@ function _tests() {
       var received = 0;
       var readable = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           var _this2 = this;
 
           setImmediate(function () {
@@ -467,7 +467,7 @@ function _tests() {
       var max = 42;
       var readed = 0;
       var readable = new Readable({
-        read: function () {
+        read: function read() {
           var _this3 = this;
 
           setImmediate(function () {
@@ -516,7 +516,7 @@ function _tests() {
     yield _asyncToGenerator(function* () {
       console.log('.next() on destroyed stream');
       var readable = new Readable({
-        read: function () {// no-op
+        read: function read() {// no-op
         }
       });
       readable.destroy();
@@ -529,7 +529,7 @@ function _tests() {
     yield _asyncToGenerator(function* () {
       console.log('.next() on pipelined stream');
       var readable = new Readable({
-        read: function () {// no-op
+        read: function read() {// no-op
         }
       });
       var passthrough = new PassThrough();
@@ -549,7 +549,7 @@ function _tests() {
       console.log('iterating on an ended stream completes');
       var r = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           this.push('asdf');
           this.push('hehe');
           this.push(null);
@@ -609,7 +609,7 @@ function _tests() {
       console.log('destroy mid-stream does not error');
       var r = new Readable({
         objectMode: true,
-        read: function () {
+        read: function read() {
           this.push('asdf');
           this.push('hehe');
         }

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -17,7 +17,7 @@ var _require2 = require('util'),
 
 {
   var read = new Readable({
-    read: function () {}
+    read: function read() {}
   });
   read.resume();
   read.on('close', common.mustCall());
@@ -26,7 +26,7 @@ var _require2 = require('util'),
 }
 {
   var _read = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _read.resume();
@@ -47,7 +47,7 @@ var _require2 = require('util'),
 }
 {
   var _read2 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _read2._destroy = common.mustCall(function (err, cb) {
@@ -71,7 +71,7 @@ var _require2 = require('util'),
 }
 {
   var _read3 = new Readable({
-    read: function () {},
+    read: function read() {},
     destroy: common.mustCall(function (err, cb) {
       assert.strictEqual(err, _expected2);
       cb();
@@ -93,7 +93,7 @@ var _require2 = require('util'),
 }
 {
   var _read4 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _read4._destroy = common.mustCall(function (err, cb) {
@@ -107,7 +107,7 @@ var _require2 = require('util'),
 }
 {
   var _read5 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _read5.resume();
@@ -138,7 +138,7 @@ var _require2 = require('util'),
 }
 {
   var _read6 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   var _expected3 = new Error('kaboom');
@@ -160,7 +160,7 @@ var _require2 = require('util'),
 }
 {
   var _read7 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _read7.resume();
@@ -173,11 +173,11 @@ var _require2 = require('util'),
   _read7.destroy();
 }
 {
-  function MyReadable() {
+  var MyReadable = function MyReadable() {
     assert.strictEqual(this.destroyed, false);
     this.destroyed = false;
     Readable.call(this);
-  }
+  };
 
   inherits(MyReadable, Readable);
   new MyReadable();
@@ -185,7 +185,7 @@ var _require2 = require('util'),
 {
   // destroy and destroy callback
   var _read8 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _read8.resume();
@@ -200,7 +200,7 @@ var _require2 = require('util'),
 }
 {
   var _read9 = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _read9.destroy();

--- a/test/parallel/test-stream-readable-emittedReadable.js
+++ b/test/parallel/test-stream-readable-emittedReadable.js
@@ -12,7 +12,7 @@ var assert = require('assert/');
 var Readable = require('../../').Readable;
 
 var readable = new Readable({
-  read: function () {}
+  read: function read() {}
 }); // Initialized to false.
 
 assert.strictEqual(readable._readableState.emittedReadable, false);
@@ -42,7 +42,7 @@ setImmediate(common.mustCall(function () {
   }));
 }));
 var noRead = new Readable({
-  read: function () {}
+  read: function read() {}
 });
 noRead.on('readable', common.mustCall(function () {
   // emittedReadable should be true when the readable event is emitted
@@ -54,7 +54,7 @@ noRead.on('readable', common.mustCall(function () {
 noRead.push('foo');
 noRead.push(null);
 var flowing = new Readable({
-  read: function () {}
+  read: function read() {}
 });
 flowing.on('data', common.mustCall(function () {
   // When in flowing mode, emittedReadable is always false.

--- a/test/parallel/test-stream-readable-invalid-chunk.js
+++ b/test/parallel/test-stream-readable-invalid-chunk.js
@@ -10,7 +10,7 @@ var common = require('../common');
 var stream = require('../../');
 
 var readable = new stream.Readable({
-  read: function () {}
+  read: function read() {}
 });
 
 function checkError(fn) {

--- a/test/parallel/test-stream-readable-needReadable.js
+++ b/test/parallel/test-stream-readable-needReadable.js
@@ -12,7 +12,7 @@ var assert = require('assert/');
 var Readable = require('../../').Readable;
 
 var readable = new Readable({
-  read: function () {}
+  read: function read() {}
 }); // Initialized to false.
 
 assert.strictEqual(readable._readableState.needReadable, false);
@@ -30,7 +30,7 @@ readable.on('end', common.mustCall(function () {
   assert.strictEqual(readable._readableState.needReadable, false);
 }));
 var asyncReadable = new Readable({
-  read: function () {}
+  read: function read() {}
 });
 asyncReadable.on('readable', common.mustCall(function () {
   if (asyncReadable.read() !== null) {
@@ -51,7 +51,7 @@ setImmediate(common.mustCall(function () {
   assert.strictEqual(asyncReadable._readableState.needReadable, false);
 }));
 var flowing = new Readable({
-  read: function () {}
+  read: function read() {}
 }); // Notice this must be above the on('data') call.
 
 flowing.push('foooo');
@@ -66,7 +66,7 @@ flowing.on('data', common.mustCall(function (data) {
   assert.strictEqual(flowing._readableState.needReadable, false);
 }, 3));
 var slowProducer = new Readable({
-  read: function () {}
+  read: function read() {}
 });
 slowProducer.on('readable', common.mustCall(function () {
   if (slowProducer.read(8) === null) {

--- a/test/parallel/test-stream-readable-no-unneeded-readable.js
+++ b/test/parallel/test-stream-readable-no-unneeded-readable.js
@@ -13,7 +13,7 @@ var _require = require('../../'),
 
 function test(r) {
   var wrapper = new Readable({
-    read: function () {
+    read: function read() {
       var data = r.read();
 
       if (data) {
@@ -40,7 +40,7 @@ function test(r) {
 
 {
   var source = new Readable({
-    read: function () {}
+    read: function read() {}
   });
   source.push('foo');
   source.push('bar');
@@ -52,7 +52,7 @@ function test(r) {
   // This is the underlying cause of the above test case.
   var pushChunks = ['foo', 'bar'];
   var r = new Readable({
-    read: function () {
+    read: function read() {
       var chunk = pushChunks.shift();
 
       if (chunk) {

--- a/test/parallel/test-stream-readable-object-multi-push-async.js
+++ b/test/parallel/test-stream-readable-object-multi-push-async.js
@@ -15,6 +15,21 @@ var _require = require('../../'),
 var MAX = 42;
 var BATCH = 10;
 {
+  var fetchData = function fetchData(cb) {
+    if (i > MAX) {
+      setTimeout(cb, 10, null, []);
+    } else {
+      var array = [];
+      var max = i + BATCH;
+
+      for (; i < max; i++) {
+        array.push(i);
+      }
+
+      setTimeout(cb, 10, null, array);
+    }
+  };
+
   var readable = new Readable({
     objectMode: true,
     read: common.mustCall(function () {
@@ -44,22 +59,6 @@ var BATCH = 10;
     }, Math.floor(MAX / BATCH) + 2)
   });
   var i = 0;
-
-  function fetchData(cb) {
-    if (i > MAX) {
-      setTimeout(cb, 10, null, []);
-    } else {
-      var array = [];
-      var max = i + BATCH;
-
-      for (; i < max; i++) {
-        array.push(i);
-      }
-
-      setTimeout(cb, 10, null, array);
-    }
-  }
-
   readable.on('readable', function () {
     var data;
     console.log('readable emitted');
@@ -73,13 +72,29 @@ var BATCH = 10;
   }));
 }
 {
+  var _fetchData = function _fetchData(cb) {
+    if (_i > MAX) {
+      setTimeout(cb, 10, null, []);
+    } else {
+      var array = [];
+      var max = _i + BATCH;
+
+      for (; _i < max; _i++) {
+        array.push(_i);
+      }
+
+      setTimeout(cb, 10, null, array);
+    }
+  };
+
   var _readable = new Readable({
     objectMode: true,
     read: common.mustCall(function () {
       var _this2 = this;
 
       console.log('>> READ');
-      fetchData(function (err, data) {
+
+      _fetchData(function (err, data) {
         if (err) {
           _this2.destroy(err);
 
@@ -104,21 +119,6 @@ var BATCH = 10;
 
   var _i = 0;
 
-  function fetchData(cb) {
-    if (_i > MAX) {
-      setTimeout(cb, 10, null, []);
-    } else {
-      var array = [];
-      var max = _i + BATCH;
-
-      for (; _i < max; _i++) {
-        array.push(_i);
-      }
-
-      setTimeout(cb, 10, null, array);
-    }
-  }
-
   _readable.on('data', function (data) {
     console.log('data emitted', data);
   });
@@ -128,13 +128,25 @@ var BATCH = 10;
   }));
 }
 {
+  var _fetchData2 = function _fetchData2(cb) {
+    var array = [];
+    var max = _i2 + BATCH;
+
+    for (; _i2 < max; _i2++) {
+      array.push(_i2);
+    }
+
+    setTimeout(cb, 10, null, array);
+  };
+
   var _readable2 = new Readable({
     objectMode: true,
     read: common.mustCall(function () {
       var _this3 = this;
 
       console.log('>> READ');
-      fetchData(function (err, data) {
+
+      _fetchData2(function (err, data) {
         if (err) {
           _this3.destroy(err);
 
@@ -156,17 +168,6 @@ var BATCH = 10;
   });
 
   var _i2 = 0;
-
-  function fetchData(cb) {
-    var array = [];
-    var max = _i2 + BATCH;
-
-    for (; _i2 < max; _i2++) {
-      array.push(_i2);
-    }
-
-    setTimeout(cb, 10, null, array);
-  }
 
   _readable2.on('data', function (data) {
     console.log('data emitted', data);

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -14,7 +14,7 @@ var ticks = 18;
 var expectedData = 19;
 var rs = new Readable({
   objectMode: true,
-  read: function () {
+  read: function read() {
     if (ticks-- > 0) return process.nextTick(function () {
       return rs.push({});
     });

--- a/test/parallel/test-stream-readable-reading-readingMore.js
+++ b/test/parallel/test-stream-readable-reading-readingMore.js
@@ -12,8 +12,15 @@ var assert = require('assert/');
 var Readable = require('../../').Readable;
 
 {
+  var onStreamEnd = function onStreamEnd() {
+    // End of stream; state.reading is false
+    // And so should be readingMore.
+    assert.strictEqual(state.readingMore, false);
+    assert.strictEqual(state.reading, false);
+  };
+
   var readable = new Readable({
-    read: function (size) {}
+    read: function read(size) {}
   });
   var state = readable._readableState; // Starting off with false initially.
 
@@ -26,14 +33,6 @@ var Readable = require('../../').Readable;
 
     assert.strictEqual(state.reading, !state.ended);
   }, 2));
-
-  function onStreamEnd() {
-    // End of stream; state.reading is false
-    // And so should be readingMore.
-    assert.strictEqual(state.readingMore, false);
-    assert.strictEqual(state.reading, false);
-  }
-
   var expectedReadingMore = [true, false];
   readable.on('readable', common.mustCall(function () {
     // there is only one readingMore scheduled from on('data'),
@@ -57,8 +56,15 @@ var Readable = require('../../').Readable;
   readable.push(null);
 }
 {
+  var _onStreamEnd = function _onStreamEnd() {
+    // End of stream; state.reading is false
+    // And so should be readingMore.
+    assert.strictEqual(_state.readingMore, false);
+    assert.strictEqual(_state.reading, false);
+  };
+
   var _readable = new Readable({
-    read: function (size) {}
+    read: function read(size) {}
   });
 
   var _state = _readable._readableState; // Starting off with false initially.
@@ -74,14 +80,7 @@ var Readable = require('../../').Readable;
     assert.strictEqual(_state.reading, !_state.ended);
   }, 2));
 
-  function onStreamEnd() {
-    // End of stream; state.reading is false
-    // And so should be readingMore.
-    assert.strictEqual(_state.readingMore, false);
-    assert.strictEqual(_state.reading, false);
-  }
-
-  _readable.on('end', common.mustCall(onStreamEnd));
+  _readable.on('end', common.mustCall(_onStreamEnd));
 
   _readable.push('pushed'); // stop emitting 'data' events
 
@@ -105,8 +104,15 @@ var Readable = require('../../').Readable;
   _readable.push(null);
 }
 {
+  var _onStreamEnd2 = function _onStreamEnd2() {
+    // End of stream; state.reading is false
+    // And so should be readingMore.
+    assert.strictEqual(_state2.readingMore, false);
+    assert.strictEqual(_state2.reading, false);
+  };
+
   var _readable2 = new Readable({
-    read: function (size) {}
+    read: function read(size) {}
   });
 
   var _state2 = _readable2._readableState; // Starting off with false initially.
@@ -124,14 +130,7 @@ var Readable = require('../../').Readable;
 
   _readable2.removeListener('readable', onReadable);
 
-  function onStreamEnd() {
-    // End of stream; state.reading is false
-    // And so should be readingMore.
-    assert.strictEqual(_state2.readingMore, false);
-    assert.strictEqual(_state2.reading, false);
-  }
-
-  _readable2.on('end', common.mustCall(onStreamEnd));
+  _readable2.on('end', common.mustCall(_onStreamEnd2));
 
   _readable2.push('pushed'); // we are still not flowing, we will be resuming in the next tick
 

--- a/test/parallel/test-stream-readable-resumeScheduled.js
+++ b/test/parallel/test-stream-readable-resumeScheduled.js
@@ -17,7 +17,7 @@ var _require = require('../../'),
 {
   // pipe() test case
   var r = new Readable({
-    read: function () {}
+    read: function read() {}
   });
   var w = new Writable(); // resumeScheduled should start = `false`.
 
@@ -32,7 +32,7 @@ var _require = require('../../'),
 {
   // 'data' listener test case
   var _r = new Readable({
-    read: function () {}
+    read: function read() {}
   }); // resumeScheduled should start = `false`.
 
 
@@ -53,7 +53,7 @@ var _require = require('../../'),
 {
   // resume() test case
   var _r2 = new Readable({
-    read: function () {}
+    read: function read() {}
   }); // resumeScheduled should start = `false`.
 
 

--- a/test/parallel/test-stream-readableListening-state.js
+++ b/test/parallel/test-stream-readableListening-state.js
@@ -12,7 +12,7 @@ var assert = require('assert/');
 var stream = require('../../');
 
 var r = new stream.Readable({
-  read: function () {}
+  read: function read() {}
 }); // readableListening state should start in `false`.
 
 assert.strictEqual(r._readableState.readableListening, false);
@@ -22,7 +22,7 @@ r.on('readable', common.mustCall(function () {
 }));
 r.push(bufferShim.from('Testing readableListening state'));
 var r2 = new stream.Readable({
-  read: function () {}
+  read: function read() {}
 }); // readableListening state should start in `false`.
 
 assert.strictEqual(r2._readableState.readableListening, false);

--- a/test/parallel/test-stream-transform-callback-twice.js
+++ b/test/parallel/test-stream-transform-callback-twice.js
@@ -11,7 +11,7 @@ var _require = require('../../'),
     Transform = _require.Transform;
 
 var stream = new Transform({
-  transform: function (chunk, enc, cb) {
+  transform: function transform(chunk, enc, cb) {
     cb();
     cb();
   }

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -14,7 +14,7 @@ var assert = require('assert/');
 
 {
   var transform = new Transform({
-    transform: function (chunk, enc, cb) {}
+    transform: function transform(chunk, enc, cb) {}
   });
   transform.resume();
   transform.on('end', common.mustNotCall());
@@ -24,7 +24,7 @@ var assert = require('assert/');
 }
 {
   var _transform = new Transform({
-    transform: function (chunk, enc, cb) {}
+    transform: function transform(chunk, enc, cb) {}
   });
 
   _transform.resume();
@@ -45,7 +45,7 @@ var assert = require('assert/');
 }
 {
   var _transform2 = new Transform({
-    transform: function (chunk, enc, cb) {}
+    transform: function transform(chunk, enc, cb) {}
   });
 
   _transform2._destroy = common.mustCall(function (err, cb) {
@@ -69,7 +69,7 @@ var assert = require('assert/');
   var _expected2 = new Error('kaboom');
 
   var _transform3 = new Transform({
-    transform: function (chunk, enc, cb) {},
+    transform: function transform(chunk, enc, cb) {},
     destroy: common.mustCall(function (err, cb) {
       assert.strictEqual(err, _expected2);
       cb();
@@ -91,7 +91,7 @@ var assert = require('assert/');
 }
 {
   var _transform4 = new Transform({
-    transform: function (chunk, enc, cb) {}
+    transform: function transform(chunk, enc, cb) {}
   });
 
   _transform4._destroy = common.mustCall(function (err, cb) {
@@ -103,7 +103,7 @@ var assert = require('assert/');
 }
 {
   var _transform5 = new Transform({
-    transform: function (chunk, enc, cb) {}
+    transform: function transform(chunk, enc, cb) {}
   });
 
   _transform5.resume();
@@ -140,7 +140,7 @@ var assert = require('assert/');
 }
 {
   var _transform6 = new Transform({
-    transform: function (chunk, enc, cb) {}
+    transform: function transform(chunk, enc, cb) {}
   });
 
   var _expected3 = new Error('kaboom');

--- a/test/parallel/test-stream-uint8array.js
+++ b/test/parallel/test-stream-uint8array.js
@@ -88,7 +88,7 @@ var GHI = new Uint8Array([0x47, 0x48, 0x49]);
 {
   // Simple Readable test.
   var readable = new Readable({
-    read: function () {}
+    read: function read() {}
   });
   readable.push(DEF);
   readable.unshift(ABC);
@@ -99,7 +99,7 @@ var GHI = new Uint8Array([0x47, 0x48, 0x49]);
 {
   // Readable test, setEncoding.
   var _readable = new Readable({
-    read: function () {}
+    read: function read() {}
   });
 
   _readable.setEncoding('utf8');

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -17,7 +17,7 @@ var _require2 = require('util'),
 
 {
   var write = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -28,7 +28,7 @@ var _require2 = require('util'),
 }
 {
   var _write = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -49,7 +49,7 @@ var _require2 = require('util'),
 }
 {
   var _write2 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -75,7 +75,7 @@ var _require2 = require('util'),
 }
 {
   var _write3 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     },
     destroy: common.mustCall(function (err, cb) {
@@ -99,7 +99,7 @@ var _require2 = require('util'),
 }
 {
   var _write4 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -115,7 +115,7 @@ var _require2 = require('util'),
 }
 {
   var _write5 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -146,7 +146,7 @@ var _require2 = require('util'),
 }
 {
   var _write6 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -173,7 +173,7 @@ var _require2 = require('util'),
 {
   // double error case
   var _write7 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -191,7 +191,7 @@ var _require2 = require('util'),
 }
 {
   var _write8 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });
@@ -204,11 +204,11 @@ var _require2 = require('util'),
   _write8.destroy();
 }
 {
-  function MyWritable() {
+  var MyWritable = function MyWritable() {
     assert.strictEqual(this.destroyed, false);
     this.destroyed = false;
     Writable.call(this);
-  }
+  };
 
   inherits(MyWritable, Writable);
   new MyWritable();
@@ -216,7 +216,7 @@ var _require2 = require('util'),
 {
   // destroy and destroy callback
   var _write9 = new Writable({
-    write: function (chunk, enc, cb) {
+    write: function write(chunk, enc, cb) {
       cb();
     }
   });

--- a/test/parallel/test-stream-write-final.js
+++ b/test/parallel/test-stream-write-final.js
@@ -20,7 +20,7 @@ var w = new stream.Writable({
       cb();
     }, 100);
   }),
-  write: function (chunk, e, cb) {
+  write: function write(chunk, e, cb) {
     process.nextTick(cb);
   }
 });

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -120,6 +120,16 @@ function (_EE) {
 }(EE);
 
 {
+  var flow = function flow() {
+    var res;
+
+    while (null !== (res = r.read(readSize++))) {
+      reads.push(res.toString());
+    }
+
+    r.once('readable', flow);
+  };
+
   // Test basic functionality
   var r = new TestReader(20);
   var reads = [];
@@ -128,17 +138,6 @@ function (_EE) {
     assert.deepStrictEqual(reads, expect);
   }));
   var readSize = 1;
-
-  function flow() {
-    var res;
-
-    while (null !== (res = r.read(readSize++))) {
-      reads.push(res.toString());
-    }
-
-    r.once('readable', flow);
-  }
-
   flow();
 }
 {

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -26,9 +26,14 @@ var stream = require('../../');
     highWaterMark: ovfl
   });
   assert.strictEqual(writable._writableState.highWaterMark, ovfl);
+  var _arr = [true, false, '5', {}, -5, NaN];
 
-  var _loop = function (invalidHwm) {
-    var _loop2 = function (type) {
+  var _loop = function _loop() {
+    var invalidHwm = _arr[_i];
+    var _arr2 = [stream.Readable, stream.Writable];
+
+    var _loop2 = function _loop2() {
+      var type = _arr2[_i2];
       common.expectsError(function () {
         type({
           highWaterMark: invalidHwm
@@ -40,21 +45,13 @@ var stream = require('../../');
       });
     };
 
-    var _arr2 = [stream.Readable, stream.Writable];
-
     for (var _i2 = 0; _i2 < _arr2.length; _i2++) {
-      var type = _arr2[_i2];
-
-      _loop2(type);
+      _loop2();
     }
   };
 
-  var _arr = [true, false, '5', {}, -5, NaN];
-
   for (var _i = 0; _i < _arr.length; _i++) {
-    var invalidHwm = _arr[_i];
-
-    _loop(invalidHwm);
+    _loop();
   }
 }
 {


### PR DESCRIPTION
Closes #394. This:

1. Uses [`@babel/preset-env`](https://babeljs.io/docs/en/next/babel-preset-env.html) exclusively, which reduces `devDependencies` and ensures we have all the necessary transforms to support intended target environments
1. Moves babel configuration to `.babelrc`, ensuring that `build/build.js` and `npm run update-browser-errors` use the same setup.

As a result, there are now 12 new transforms applied to code imported from node core. Most notably (going by the amount of diff):

- [`transform-block-scoped-functions`](https://babeljs.io/docs/en/next/babel-plugin-transform-block-scoped-functions.html)
  - Transforms `function foo () {}` to hoisted `var foo = function () {}`
  - Required only for Android
- [`transform-function-name`](https://babeljs.io/docs/en/next/babel-plugin-transform-function-name.html)
  - Transforms anonymous functions to named functions
  - For Android, Edge 17, IE 11 and Node 6, which can't infer function names. Is there any streams code that relies on `function.name` though?

From the new transforms, I excluded:

- [`transform-typeof-symbol`](https://babeljs.io/docs/en/next/babel-plugin-transform-typeof-symbol.html) because a quick benchmark showed that its fallback is 2-3x slower than native `typeof`, we have replacements in place for `Symbol` usage and I couldn't find any code like `typeof Symbol()`.
- [`transform-regenerator`](https://babeljs.io/docs/en/next/babel-plugin-transform-regenerator.html) because it'd only apply to tests and I think we shouldn't transpile "optional features" (like generators and async functions) but rather run tests selectively in target environments that support these features.

We may want to exclude some target environments as well if they're not officially supported. For example, do we support Android?

---

Here's a full list of resolved targets and plugins, logged by `@babel/preset-env`:

<details>
<summary>Click to expand</summary>

```
Using targets:
{
  "android": "4.4.3",
  "chrome": "69",
  "edge": "17",
  "firefox": "62",
  "ie": "11",
  "ios": "11.3",
  "node": "6",
  "opera": "56",
  "safari": "11.1"
}

Using modules transform: commonjs

Using plugins:
  transform-template-literals { "android":"4.4.3", "ie":"11" }
  transform-literals { "android":"4.4.3", "ie":"11" }
  transform-function-name { "android":"4.4.3", "edge":"17", "ie":"11", "node":"6" }
  transform-arrow-functions { "android":"4.4.3", "ie":"11" }
  transform-block-scoped-functions { "android":"4.4.3" }
  transform-classes { "android":"4.4.3", "ie":"11" }
  transform-object-super { "android":"4.4.3", "ie":"11" }
  transform-shorthand-properties { "android":"4.4.3", "ie":"11" }
  transform-duplicate-keys { "android":"4.4.3", "ie":"11" }
  transform-computed-properties { "android":"4.4.3", "ie":"11" }
  transform-for-of { "android":"4.4.3", "ie":"11", "node":"6" }
  transform-sticky-regex { "android":"4.4.3", "ie":"11" }
  transform-dotall-regex { "android":"4.4.3", "edge":"17", "firefox":"62", "ie":"11", "node":"6" }
  transform-unicode-regex { "android":"4.4.3", "ie":"11", "ios":"11.3", "safari":"11.1" }
  transform-spread { "android":"4.4.3", "ie":"11" }
  transform-parameters { "android":"4.4.3", "edge":"17", "ie":"11" }
  transform-destructuring { "android":"4.4.3", "edge":"17", "ie":"11", "node":"6" }
  transform-block-scoping { "android":"4.4.3", "ie":"11" }
  transform-new-target { "android":"4.4.3", "ie":"11" }
  transform-exponentiation-operator { "android":"4.4.3", "ie":"11", "node":"6" }
  transform-async-to-generator { "android":"4.4.3", "ie":"11", "node":"6" }
  proposal-async-generator-functions { "android":"4.4.3", "edge":"17", "ie":"11", "ios":"11.3", "node":"6", "safari":"11.1" }
  proposal-object-rest-spread { "android":"4.4.3", "edge":"17", "ie":"11", "node":"6" }
  proposal-unicode-property-regex { "android":"4.4.3", "edge":"17", "firefox":"62", "ie":"11", "node":"6" }
  proposal-json-strings { "android":"4.4.3", "chrome":"69", "edge":"17", "firefox":"62", "ie":"11", "ios":"11.3", "node":"6", "opera":"56", "safari":"11.1" }
  proposal-optional-catch-binding { "android":"4.4.3", "edge":"17", "ie":"11", "node":"6" }

Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
```
</details>

---

Of those plugins, the following are new to `build/build.js` (not necessarily used):

<details>
<summary>Click to expand</summary>

- [`transform-block-scoped-functions`](https://babeljs.io/docs/en/next/babel-plugin-transform-block-scoped-functions.html)
- [`transform-function-name`](https://babeljs.io/docs/en/next/babel-plugin-transform-function-name.html)
- [`transform-duplicate-keys`](https://babeljs.io/docs/en/next/babel-plugin-transform-duplicate-keys.html)
- [`transform-new-target`](https://babeljs.io/docs/en/next/babel-plugin-transform-new-target.html)
- [`transform-object-super`](https://babeljs.io/docs/en/next/babel-plugin-transform-object-super.html)
- [`proposal-unicode-property-regex`](https://babeljs.io/docs/en/next/babel-plugin-proposal-unicode-property-regex.html)
- [`transform-unicode-regex`](https://babeljs.io/docs/en/next/babel-plugin-transform-unicode-regex.html)
- [`transform-sticky-regex`](https://babeljs.io/docs/en/next/babel-plugin-transform-sticky-regex.html)
- [`transform-dotall-regex`](https://babeljs.io/docs/en/next/babel-plugin-transform-dotall-regex.html)
- [`transform-exponentiation-operator`](https://babeljs.io/docs/en/next/babel-plugin-transform-exponentiation-operator.html)
- [`proposal-json-strings`](https://babeljs.io/docs/en/next/babel-plugin-proposal-json-strings.html)
- [`transform-literals`](https://babeljs.io/docs/en/next/babel-plugin-transform-literals.html)

</details>