### PR TITLE
add missing exports for browsers

### DIFF
--- a/readable-browser.js
+++ b/readable-browser.js
@@ -5,3 +5,5 @@ exports.Writable = require('./lib/_stream_writable.js');
 exports.Duplex = require('./lib/_stream_duplex.js');
 exports.Transform = require('./lib/_stream_transform.js');
 exports.PassThrough = require('./lib/_stream_passthrough.js');
+exports.finished = require('./lib/internal/streams/end-of-stream.js');
+exports.pipeline = require('./lib/internal/streams/pipeline.js');

--- a/test/browser.js
+++ b/test/browser.js
@@ -33,6 +33,7 @@ test('streams', function (t) {
   require('./browser/test-stream-duplex')(t);
   require('./browser/test-stream-end-paused')(t);
   require('./browser/test-stream-ispaused')(t);
+  require('./browser/test-stream-finished')(t);
   require('./browser/test-stream-pipe-after-end')(t);
   require('./browser/test-stream-pipe-cleanup')(t);
   require('./browser/test-stream-pipe-cleanup-pause')(t);

--- a/test/browser.js
+++ b/test/browser.js
@@ -34,6 +34,7 @@ test('streams', function (t) {
   require('./browser/test-stream-end-paused')(t);
   require('./browser/test-stream-ispaused')(t);
   require('./browser/test-stream-finished')(t);
+  require('./browser/test-stream-pipeline')(t);
   require('./browser/test-stream-pipe-after-end')(t);
   require('./browser/test-stream-pipe-cleanup')(t);
   require('./browser/test-stream-pipe-cleanup-pause')(t);

--- a/test/browser/test-stream-finished.js
+++ b/test/browser/test-stream-finished.js
@@ -1,0 +1,60 @@
+"use strict";
+
+
+var common = require('../common');
+
+var _require = require('../../'),
+    Writable = _require.Writable,
+    Readable = _require.Readable,
+    Transform = _require.Transform,
+    finished = _require.finished;
+
+module.exports = function (t) {
+  t.test('readable finished', function (t) {
+
+    var rs = new Readable({
+      read: function read() {}
+    });
+    finished(rs, common.mustCall(function (err) {
+      t.ok(!err, 'no error');
+      t.end();
+    }));
+    rs.push(null);
+    rs.resume();
+  });
+  t.test('writable finished', function (t) {
+    var ws = new Writable({
+      write: function write(data, enc, cb) {
+        cb();
+      }
+    });
+    finished(ws, common.mustCall(function (err) {
+      t.ok(!err, 'no error');
+      t.end();
+    }));
+    ws.end();
+  });
+  t.test('transform finished', function (t) {
+    var tr = new Transform({
+      transform: function transform(data, enc, cb) {
+        cb();
+      }
+    });
+    var finish = false;
+    var ended = false;
+    tr.on('end', function () {
+      ended = true;
+    });
+    tr.on('finish', function () {
+      finish = true;
+    });
+    finished(tr, common.mustCall(function (err) {
+      t.ok(!err, 'no error');
+      t.ok(finish);
+      t.ok(ended);
+      t.end();
+    }));
+    tr.end();
+    tr.resume();
+  });
+};

--- a/test/browser/test-stream-pipeline.js
+++ b/test/browser/test-stream-pipeline.js
@@ -1,0 +1,112 @@
+"use strict";
+
+/*<replacement>*/
+var bufferShim = require('safe-buffer').Buffer;
+/*</replacement>*/
+
+var common = require('../common');
+
+var _require = require('../../'),
+    Writable = _require.Writable,
+    Readable = _require.Readable,
+    Transform = _require.Transform,
+    finished = _require.finished,
+    pipeline = _require.pipeline;
+
+module.exports = function (t) {
+  t.test('pipeline', function (t) {
+    var finished = false;
+    var processed = [];
+    var expected = [bufferShim.from('a'), bufferShim.from('b'),
+      bufferShim.from('c')];
+    var read = new Readable({
+      read: function read() {
+      }
+    });
+    var write = new Writable({
+      write: function write(data, enc, cb) {
+        processed.push(data);
+        cb();
+      }
+    });
+    write.on('finish', function () {
+      finished = true;
+    });
+
+    for (var i = 0; i < expected.length; i++) {
+      read.push(expected[i]);
+    }
+
+    read.push(null);
+    pipeline(read, write, common.mustCall(function (err) {
+      t.ok(!err, 'no error');
+      t.ok(finished);
+      t.deepEqual(processed, expected);
+      t.end();
+    }));
+  });
+  t.test('pipeline missing args', function (t) {
+    var _read = new Readable({
+      read: function read() {
+      }
+    });
+
+    t.throws(function () {
+      pipeline(_read, function () {
+      });
+    }, /ERR_MISSING_ARGS/);
+    t.throws(function () {
+      pipeline(function () {
+      });
+    }, /ERR_MISSING_ARGS/);
+    t.throws(function () {
+      pipeline();
+    }, /ERR_MISSING_ARGS/);
+    t.end();
+  });
+  t.test('pipeline error', function (t) {
+    var _read2 = new Readable({
+      read: function read() {
+      }
+    });
+
+    var _write = new Writable({
+      write: function write(data, enc, cb) {
+        cb();
+      }
+    });
+
+    _read2.push('data');
+
+    setImmediate(function () {
+      return _read2.destroy();
+    });
+    pipeline(_read2, _write, common.mustCall(function (err) {
+      t.ok(err, 'should have an error');
+      t.end();
+    }));
+  });
+  t.test('pipeline destroy', function () {
+    var _read3 = new Readable({
+      read: function read() {
+      }
+    });
+
+    var _write2 = new Writable({
+      write: function write(data, enc, cb) {
+        cb();
+      }
+    });
+
+    _read3.push('data');
+
+    setImmediate(function () {
+      return _read3.destroy(new Error('kaboom'));
+    });
+    var dst = pipeline(_read3, _write2, common.mustCall(function (err) {
+      t.equal(err.message, 'kaboom');
+      t.end();
+    }));
+    t.equal(dst, _write2);
+  });
+};


### PR DESCRIPTION
This PR adds the missing exports, mentioned in https://github.com/nodejs/readable-stream/issues/408

There should be tests, that would have catched the problem beforehand, but I did not figure out how to add those in reasonable time. I appreciate, if someone more experienced with this project adds those tests.