### PR TITLE
modify write method for Uint8Array output

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -285,9 +285,15 @@ Writable.prototype.write = function (chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
 
-  var isBuf = !state.objectMode && _isUint8Array(chunk);
+  // var isBuf = !state.objectMode && _isUint8Array(chunk);
 
-  if (isBuf && !Buffer.isBuffer(chunk)) {
+  // if (isBuf && !Buffer.isBuffer(chunk)) {
+  //   chunk = _uint8ArrayToBuffer(chunk);
+  // }
+
+  var isBuf = _isUint8Array(chunk);
+
+  if (isBuf) {
     chunk = _uint8ArrayToBuffer(chunk);
   }
 


### PR DESCRIPTION
When I use MQTT.js in wechat and publish ArrayBuffer message，the subclient cannot recv the message.
I debugged the program and found in _stream_writable.js "write" method the ArrayBuffer  payload encoding is converted to “utf-8”,cannot convert to Buffer。
I've made changes and passed the test in the project.