### PR TITLE
Fixing a TypeError bug when state is undefined

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -558,13 +558,13 @@ Writable.prototype.end = function (chunk, encoding, cb) {
 
   if (chunk !== null && chunk !== undefined) this.write(chunk, encoding); // .end() fully uncorks
 
-  if (state.corked) {
+  if (state && state.corked) {
     state.corked = 1;
     this.uncork();
   } // ignore unnecessary end() calls.
 
 
-  if (!state.ending) endWritable(this, state, cb);
+  if (state && !state.ending) endWritable(this, state, cb);
   return this;
 };
 


### PR DESCRIPTION
I'm fixing a bug. Sometimes state is undefined and I get a Type Error:
"TypeError: Cannot read property 'corked' of undefined"