### PR TITLE
v2.x - do not mutate core-util-is module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: node_js
 before_install:
-  - npm install -g npm@2
-  - test $NPM_LEGACY && npm install -g npm@latest-3 || npm install npm -g
+  - (test $NPM_LEGACY && npm install -g npm@2 && npm install -g npm@3) || true
 notifications:
   email: false
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,46 +8,26 @@ matrix:
   fast_finish: true
   include:
   - node_js: '0.8'
-    env:
-      - TASK=test
-      - NPM_LEGACY=true
+    env: NPM_LEGACY=true
   - node_js: '0.10'
-    env:
-      - TASK=test
-      - NPM_LEGACY=true
+    env: NPM_LEGACY=true
   - node_js: '0.11'
-    env:
-      - TASK=test
-      - NPM_LEGACY=true
+    env: NPM_LEGACY=true
   - node_js: '0.12'
-    env:
-      - TASK=test
-      - NPM_LEGACY=true
+    env: NPM_LEGACY=true
   - node_js: 1
-    env:
-      - TASK=test
-      - NPM_LEGACY=true
+    env: NPM_LEGACY=true
   - node_js: 2
-    env:
-      - TASK=test
-      - NPM_LEGACY=true
+    env: NPM_LEGACY=true
   - node_js: 3
-    env:
-      - TASK=test
-      - NPM_LEGACY=true
+    env: NPM_LEGACY=true
   - node_js: 4
-    env: TASK=test
   - node_js: 5
-    env: TASK=test
   - node_js: 6
-    env: TASK=test
   - node_js: 7
-    env: TASK=test
   - node_js: 8
-    env: TASK=test
   - node_js: 9
-    env: TASK=test
-script: "npm run $TASK"
+script: "npm run test"
 env:
   global:
   - secure: rE2Vvo7vnjabYNULNyLFxOyt98BoJexDqsiOnfiD6kLYYsiQGfr/sbZkPMOFm9qfQG7pjqx+zZWZjGSswhTt+626C0t/njXqug7Yps4c3dFblzGfreQHp7wNX5TFsvrxd6dAowVasMp61sJcRnB2w8cUzoe3RAYUDHyiHktwqMc=

--- a/build/files.js
+++ b/build/files.js
@@ -41,7 +41,7 @@ const headRegexp = /(^module.exports = \w+;?)/m
 
     , utilReplacement = [
           /^const util = require\('util'\);/m
-        ,   '\n/*<replacement>*/\nconst util = require(\'core-util-is\');\n'
+        ,   '\n/*<replacement>*/\nconst util = Object.create(require(\'core-util-is\'));\n'
           + 'util.inherits = require(\'inherits\');\n/*</replacement>*/\n'
       ]
 

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -43,7 +43,7 @@ var objectKeys = Object.keys || function (obj) {
 module.exports = Duplex;
 
 /*<replacement>*/
-var util = require('core-util-is');
+var util = Object.create(require('core-util-is'));
 util.inherits = require('inherits');
 /*</replacement>*/
 

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -30,7 +30,7 @@ module.exports = PassThrough;
 var Transform = require('./_stream_transform');
 
 /*<replacement>*/
-var util = require('core-util-is');
+var util = Object.create(require('core-util-is'));
 util.inherits = require('inherits');
 /*</replacement>*/
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -64,7 +64,7 @@ function _isUint8Array(obj) {
 /*</replacement>*/
 
 /*<replacement>*/
-var util = require('core-util-is');
+var util = Object.create(require('core-util-is'));
 util.inherits = require('inherits');
 /*</replacement>*/
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -68,7 +68,7 @@ module.exports = Transform;
 var Duplex = require('./_stream_duplex');
 
 /*<replacement>*/
-var util = require('core-util-is');
+var util = Object.create(require('core-util-is'));
 util.inherits = require('inherits');
 /*</replacement>*/
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -64,7 +64,7 @@ var Duplex;
 Writable.WritableState = WritableState;
 
 /*<replacement>*/
-var util = require('core-util-is');
+var util = Object.create(require('core-util-is'));
 util.inherits = require('inherits');
 /*</replacement>*/
 


### PR DESCRIPTION
### report
v2.x modifes the exports of `core-util-is` 

v2.x is still used by `browserify`'s via `stream-browserify`

The replacements inserted by the build process include some workaround for `util` and `inherits`. This seems to be an unintentional modification of the `core-util-is`.

https://github.com/nodejs/readable-stream/blob/b3cf9b1f46eaa1865930ae03b96d7a4a570746f0/lib/_stream_readable.js#L66-L69

### fix
The fix uses `Object.create(...)` to create a new object with the `core-util-is` module.exports set as its prototype. This means all the content of the original module.exports is exposed but the object can be decorated without mutating `core-util-is`.

I originally used `Object.assign({}, ...)` but `Object.create` has even wider support.

platform support details
- [`Object.create` (ES5)](http://kangax.github.io/compat-table/es5/#test-Object.create)
- [`Object.assign` (ES6)](https://caniuse.com/#search=object.assign)

### context:
I'm working on [a set of tools to help defend against software supplychain attacks](https://github.com/lavamoat/overview). One of the imposed limitations is that you cannot modify the module.exports of a module from another package. `readable-stream@2.x` is one of the only packages I've found that breaks this limitation. `readable-stream@3.x` has such issue.