### PR TITLE
[Fix] babel's "loose mode" class transform enbrittles BufferList

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,11 +13,5 @@
       ],
       "debug": true
     }]
-  ],
-  "plugins": [
-    // Included in the preset, but we can't specify per-plugin options there
-    ["@babel/plugin-transform-classes", {
-      "loose": true
-    }]
   ]
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save readable-stream
 
 This package is a mirror of the streams implementations in Node.js.
 
-Full documentation may be found on the [Node.js website](https://nodejs.org/dist/v10.18.1/docs/api/stream.html).
+Full documentation may be found on the [Node.js website](https://nodejs.org/dist/v10.19.0/docs/api/stream.html).
 
 If you want to guarantee a stable streams base, regardless of what version of
 Node you, or the users of your libraries are using, use **readable-stream** *only* and avoid the *"stream"* module in Node-core, for background see [this blogpost](http://r.va.gg/2014/06/why-i-dont-use-nodes-core-stream-module.html).

--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -6,6 +6,12 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
 var _require = require('buffer'),
     Buffer = _require.Buffer;
 
@@ -22,170 +28,183 @@ module.exports =
 /*#__PURE__*/
 function () {
   function BufferList() {
+    _classCallCheck(this, BufferList);
+
     this.head = null;
     this.tail = null;
     this.length = 0;
   }
 
-  var _proto = BufferList.prototype;
-
-  _proto.push = function push(v) {
-    var entry = {
-      data: v,
-      next: null
-    };
-    if (this.length > 0) this.tail.next = entry;else this.head = entry;
-    this.tail = entry;
-    ++this.length;
-  };
-
-  _proto.unshift = function unshift(v) {
-    var entry = {
-      data: v,
-      next: this.head
-    };
-    if (this.length === 0) this.tail = entry;
-    this.head = entry;
-    ++this.length;
-  };
-
-  _proto.shift = function shift() {
-    if (this.length === 0) return;
-    var ret = this.head.data;
-    if (this.length === 1) this.head = this.tail = null;else this.head = this.head.next;
-    --this.length;
-    return ret;
-  };
-
-  _proto.clear = function clear() {
-    this.head = this.tail = null;
-    this.length = 0;
-  };
-
-  _proto.join = function join(s) {
-    if (this.length === 0) return '';
-    var p = this.head;
-    var ret = '' + p.data;
-
-    while (p = p.next) {
-      ret += s + p.data;
+  _createClass(BufferList, [{
+    key: "push",
+    value: function push(v) {
+      var entry = {
+        data: v,
+        next: null
+      };
+      if (this.length > 0) this.tail.next = entry;else this.head = entry;
+      this.tail = entry;
+      ++this.length;
     }
-
-    return ret;
-  };
-
-  _proto.concat = function concat(n) {
-    if (this.length === 0) return Buffer.alloc(0);
-    var ret = Buffer.allocUnsafe(n >>> 0);
-    var p = this.head;
-    var i = 0;
-
-    while (p) {
-      copyBuffer(p.data, ret, i);
-      i += p.data.length;
-      p = p.next;
+  }, {
+    key: "unshift",
+    value: function unshift(v) {
+      var entry = {
+        data: v,
+        next: this.head
+      };
+      if (this.length === 0) this.tail = entry;
+      this.head = entry;
+      ++this.length;
     }
-
-    return ret;
-  } // Consumes a specified amount of bytes or characters from the buffered data.
-  ;
-
-  _proto.consume = function consume(n, hasStrings) {
-    var ret;
-
-    if (n < this.head.data.length) {
-      // `slice` is the same for buffers and strings.
-      ret = this.head.data.slice(0, n);
-      this.head.data = this.head.data.slice(n);
-    } else if (n === this.head.data.length) {
-      // First chunk is a perfect match.
-      ret = this.shift();
-    } else {
-      // Result spans more than one buffer.
-      ret = hasStrings ? this._getString(n) : this._getBuffer(n);
+  }, {
+    key: "shift",
+    value: function shift() {
+      if (this.length === 0) return;
+      var ret = this.head.data;
+      if (this.length === 1) this.head = this.tail = null;else this.head = this.head.next;
+      --this.length;
+      return ret;
     }
+  }, {
+    key: "clear",
+    value: function clear() {
+      this.head = this.tail = null;
+      this.length = 0;
+    }
+  }, {
+    key: "join",
+    value: function join(s) {
+      if (this.length === 0) return '';
+      var p = this.head;
+      var ret = '' + p.data;
 
-    return ret;
-  };
-
-  _proto.first = function first() {
-    return this.head.data;
-  } // Consumes a specified amount of characters from the buffered data.
-  ;
-
-  _proto._getString = function _getString(n) {
-    var p = this.head;
-    var c = 1;
-    var ret = p.data;
-    n -= ret.length;
-
-    while (p = p.next) {
-      var str = p.data;
-      var nb = n > str.length ? str.length : n;
-      if (nb === str.length) ret += str;else ret += str.slice(0, n);
-      n -= nb;
-
-      if (n === 0) {
-        if (nb === str.length) {
-          ++c;
-          if (p.next) this.head = p.next;else this.head = this.tail = null;
-        } else {
-          this.head = p;
-          p.data = str.slice(nb);
-        }
-
-        break;
+      while (p = p.next) {
+        ret += s + p.data;
       }
 
-      ++c;
+      return ret;
     }
+  }, {
+    key: "concat",
+    value: function concat(n) {
+      if (this.length === 0) return Buffer.alloc(0);
+      var ret = Buffer.allocUnsafe(n >>> 0);
+      var p = this.head;
+      var i = 0;
 
-    this.length -= c;
-    return ret;
-  } // Consumes a specified amount of bytes from the buffered data.
-  ;
-
-  _proto._getBuffer = function _getBuffer(n) {
-    var ret = Buffer.allocUnsafe(n);
-    var p = this.head;
-    var c = 1;
-    p.data.copy(ret);
-    n -= p.data.length;
-
-    while (p = p.next) {
-      var buf = p.data;
-      var nb = n > buf.length ? buf.length : n;
-      buf.copy(ret, ret.length - n, 0, nb);
-      n -= nb;
-
-      if (n === 0) {
-        if (nb === buf.length) {
-          ++c;
-          if (p.next) this.head = p.next;else this.head = this.tail = null;
-        } else {
-          this.head = p;
-          p.data = buf.slice(nb);
-        }
-
-        break;
+      while (p) {
+        copyBuffer(p.data, ret, i);
+        i += p.data.length;
+        p = p.next;
       }
 
-      ++c;
+      return ret;
+    } // Consumes a specified amount of bytes or characters from the buffered data.
+
+  }, {
+    key: "consume",
+    value: function consume(n, hasStrings) {
+      var ret;
+
+      if (n < this.head.data.length) {
+        // `slice` is the same for buffers and strings.
+        ret = this.head.data.slice(0, n);
+        this.head.data = this.head.data.slice(n);
+      } else if (n === this.head.data.length) {
+        // First chunk is a perfect match.
+        ret = this.shift();
+      } else {
+        // Result spans more than one buffer.
+        ret = hasStrings ? this._getString(n) : this._getBuffer(n);
+      }
+
+      return ret;
     }
+  }, {
+    key: "first",
+    value: function first() {
+      return this.head.data;
+    } // Consumes a specified amount of characters from the buffered data.
 
-    this.length -= c;
-    return ret;
-  } // Make sure the linked list only shows the minimal necessary information.
-  ;
+  }, {
+    key: "_getString",
+    value: function _getString(n) {
+      var p = this.head;
+      var c = 1;
+      var ret = p.data;
+      n -= ret.length;
 
-  _proto[custom] = function (_, options) {
-    return inspect(this, _objectSpread({}, options, {
-      // Only inspect one level.
-      depth: 0,
-      // It should not recurse.
-      customInspect: false
-    }));
-  };
+      while (p = p.next) {
+        var str = p.data;
+        var nb = n > str.length ? str.length : n;
+        if (nb === str.length) ret += str;else ret += str.slice(0, n);
+        n -= nb;
+
+        if (n === 0) {
+          if (nb === str.length) {
+            ++c;
+            if (p.next) this.head = p.next;else this.head = this.tail = null;
+          } else {
+            this.head = p;
+            p.data = str.slice(nb);
+          }
+
+          break;
+        }
+
+        ++c;
+      }
+
+      this.length -= c;
+      return ret;
+    } // Consumes a specified amount of bytes from the buffered data.
+
+  }, {
+    key: "_getBuffer",
+    value: function _getBuffer(n) {
+      var ret = Buffer.allocUnsafe(n);
+      var p = this.head;
+      var c = 1;
+      p.data.copy(ret);
+      n -= p.data.length;
+
+      while (p = p.next) {
+        var buf = p.data;
+        var nb = n > buf.length ? buf.length : n;
+        buf.copy(ret, ret.length - n, 0, nb);
+        n -= nb;
+
+        if (n === 0) {
+          if (nb === buf.length) {
+            ++c;
+            if (p.next) this.head = p.next;else this.head = this.tail = null;
+          } else {
+            this.head = p;
+            p.data = buf.slice(nb);
+          }
+
+          break;
+        }
+
+        ++c;
+      }
+
+      this.length -= c;
+      return ret;
+    } // Make sure the linked list only shows the minimal necessary information.
+
+  }, {
+    key: custom,
+    value: function value(_, options) {
+      return inspect(this, _objectSpread({}, options, {
+        // Only inspect one level.
+        depth: 0,
+        // It should not recurse.
+        customInspect: false
+      }));
+    }
+  }]);
 
   return BufferList;
 }();

--- a/test/common/countdown.js
+++ b/test/common/countdown.js
@@ -1,5 +1,7 @@
 "use strict";
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -44,21 +46,22 @@ var Countdown =
 /*#__PURE__*/
 function () {
   function Countdown(limit, cb) {
+    _classCallCheck(this, Countdown);
+
     assert.strictEqual(typeof limit, 'number');
     assert.strictEqual(typeof cb, 'function');
     this[kLimit] = limit;
     this[kCallback] = common.mustCall(cb);
   }
 
-  var _proto = Countdown.prototype;
-
-  _proto.dec = function dec() {
-    assert(this[kLimit] > 0, 'Countdown expired');
-    if (--this[kLimit] === 0) this[kCallback]();
-    return this[kLimit];
-  };
-
   _createClass(Countdown, [{
+    key: "dec",
+    value: function dec() {
+      assert(this[kLimit] > 0, 'Countdown expired');
+      if (--this[kLimit] === 0) this[kCallback]();
+      return this[kLimit];
+    }
+  }, {
     key: "remaining",
     get: function get() {
       return this[kLimit];

--- a/test/common/duplexpair.js
+++ b/test/common/duplexpair.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 /*<replacement>*/
 require('@babel/polyfill');
@@ -42,39 +56,44 @@ var kOtherSide = Symbol('Other');
 var DuplexSocket =
 /*#__PURE__*/
 function (_Duplex) {
-  _inheritsLoose(DuplexSocket, _Duplex);
+  _inherits(DuplexSocket, _Duplex);
 
   function DuplexSocket() {
     var _this;
 
-    _this = _Duplex.call(this) || this;
+    _classCallCheck(this, DuplexSocket);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(DuplexSocket).call(this));
     _this[kCallback] = null;
     _this[kOtherSide] = null;
     return _this;
   }
 
-  var _proto = DuplexSocket.prototype;
+  _createClass(DuplexSocket, [{
+    key: "_read",
+    value: function _read() {
+      var callback = this[kCallback];
 
-  _proto._read = function _read() {
-    var callback = this[kCallback];
-
-    if (callback) {
-      this[kCallback] = null;
-      callback();
+      if (callback) {
+        this[kCallback] = null;
+        callback();
+      }
     }
-  };
-
-  _proto._write = function _write(chunk, encoding, callback) {
-    assert.notStrictEqual(this[kOtherSide], null);
-    assert.strictEqual(this[kOtherSide][kCallback], null);
-    this[kOtherSide][kCallback] = callback;
-    this[kOtherSide].push(chunk);
-  };
-
-  _proto._final = function _final(callback) {
-    this[kOtherSide].on('end', callback);
-    this[kOtherSide].push(null);
-  };
+  }, {
+    key: "_write",
+    value: function _write(chunk, encoding, callback) {
+      assert.notStrictEqual(this[kOtherSide], null);
+      assert.strictEqual(this[kOtherSide][kCallback], null);
+      this[kOtherSide][kCallback] = callback;
+      this[kOtherSide].push(chunk);
+    }
+  }, {
+    key: "_final",
+    value: function _final(callback) {
+      this[kOtherSide].on('end', callback);
+      this[kOtherSide].push(null);
+    }
+  }]);
 
   return DuplexSocket;
 }(Duplex);

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -1,5 +1,11 @@
 "use strict";
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
 /*<replacement>*/
 require('@babel/polyfill');
 
@@ -83,187 +89,192 @@ var State =
 /*#__PURE__*/
 function () {
   function State() {
+    _classCallCheck(this, State);
+
     this.snapshot = createJSHeapDump();
     this.embedderGraph = buildEmbedderGraph();
   } // Validate the v8 heap snapshot
 
 
-  var _proto = State.prototype;
+  _createClass(State, [{
+    key: "validateSnapshot",
+    value: function validateSnapshot(rootName, expected) {
+      var _ref2 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
+          _ref2$loose = _ref2.loose,
+          loose = _ref2$loose === void 0 ? false : _ref2$loose;
 
-  _proto.validateSnapshot = function validateSnapshot(rootName, expected) {
-    var _ref2 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
-        _ref2$loose = _ref2.loose,
-        loose = _ref2$loose === void 0 ? false : _ref2$loose;
+      var rootNodes = this.snapshot.filter(function (node) {
+        return node.name === rootName && node.type !== 'string';
+      });
 
-    var rootNodes = this.snapshot.filter(function (node) {
-      return node.name === rootName && node.type !== 'string';
-    });
+      if (loose) {
+        assert(rootNodes.length >= expected.length, "Expect to find at least ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
+      } else {
+        assert.strictEqual(rootNodes.length, expected.length, "Expect to find ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
+      }
 
-    if (loose) {
-      assert(rootNodes.length >= expected.length, "Expect to find at least ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
-    } else {
-      assert.strictEqual(rootNodes.length, expected.length, "Expect to find ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
-    }
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
 
-    var _iteratorNormalCompletion = true;
-    var _didIteratorError = false;
-    var _iteratorError = undefined;
+      try {
+        for (var _iterator = expected[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var expectation = _step.value;
 
-    try {
-      for (var _iterator = expected[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-        var expectation = _step.value;
+          if (expectation.children) {
+            var _iteratorNormalCompletion2 = true;
+            var _didIteratorError2 = false;
+            var _iteratorError2 = undefined;
 
-        if (expectation.children) {
-          var _iteratorNormalCompletion2 = true;
-          var _didIteratorError2 = false;
-          var _iteratorError2 = undefined;
+            try {
+              var _loop = function _loop() {
+                var expectedEdge = _step2.value;
+                var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
+                  return isEdge(edge, expectedEdge);
+                };
+                var hasChild = rootNodes.some(function (node) {
+                  return node.outgoingEdges.some(check);
+                }); // Don't use assert with a custom message here. Otherwise the
+                // inspection in the message is done eagerly and wastes a lot of CPU
+                // time.
 
-          try {
-            var _loop = function _loop() {
-              var expectedEdge = _step2.value;
-              var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
-                return isEdge(edge, expectedEdge);
+                if (!hasChild) {
+                  throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
+                }
               };
-              var hasChild = rootNodes.some(function (node) {
-                return node.outgoingEdges.some(check);
-              }); // Don't use assert with a custom message here. Otherwise the
-              // inspection in the message is done eagerly and wastes a lot of CPU
-              // time.
 
-              if (!hasChild) {
-                throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
+              for (var _iterator2 = expectation.children[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                _loop();
               }
-            };
-
-            for (var _iterator2 = expectation.children[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-              _loop();
-            }
-          } catch (err) {
-            _didIteratorError2 = true;
-            _iteratorError2 = err;
-          } finally {
-            try {
-              if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
-                _iterator2.return();
-              }
+            } catch (err) {
+              _didIteratorError2 = true;
+              _iteratorError2 = err;
             } finally {
-              if (_didIteratorError2) {
-                throw _iteratorError2;
+              try {
+                if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
+                  _iterator2.return();
+                }
+              } finally {
+                if (_didIteratorError2) {
+                  throw _iteratorError2;
+                }
               }
             }
           }
         }
-      }
-    } catch (err) {
-      _didIteratorError = true;
-      _iteratorError = err;
-    } finally {
-      try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-          _iterator.return();
-        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
       } finally {
-        if (_didIteratorError) {
-          throw _iteratorError;
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return != null) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
         }
       }
-    }
-  } // Validate our internal embedded graph representation
-  ;
+    } // Validate our internal embedded graph representation
 
-  _proto.validateGraph = function validateGraph(rootName, expected) {
-    var _ref3 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
-        _ref3$loose = _ref3.loose,
-        loose = _ref3$loose === void 0 ? false : _ref3$loose;
+  }, {
+    key: "validateGraph",
+    value: function validateGraph(rootName, expected) {
+      var _ref3 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
+          _ref3$loose = _ref3.loose,
+          loose = _ref3$loose === void 0 ? false : _ref3$loose;
 
-    var rootNodes = this.embedderGraph.filter(function (node) {
-      return node.name === rootName;
-    });
+      var rootNodes = this.embedderGraph.filter(function (node) {
+        return node.name === rootName;
+      });
 
-    if (loose) {
-      assert(rootNodes.length >= expected.length, "Expect to find at least ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
-    } else {
-      assert.strictEqual(rootNodes.length, expected.length, "Expect to find ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
-    }
+      if (loose) {
+        assert(rootNodes.length >= expected.length, "Expect to find at least ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
+      } else {
+        assert.strictEqual(rootNodes.length, expected.length, "Expect to find ".concat(expected.length, " '").concat(rootName, "', ") + "found ".concat(rootNodes.length));
+      }
 
-    var _iteratorNormalCompletion3 = true;
-    var _didIteratorError3 = false;
-    var _iteratorError3 = undefined;
+      var _iteratorNormalCompletion3 = true;
+      var _didIteratorError3 = false;
+      var _iteratorError3 = undefined;
 
-    try {
-      for (var _iterator3 = expected[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-        var expectation = _step3.value;
+      try {
+        for (var _iterator3 = expected[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+          var expectation = _step3.value;
 
-        if (expectation.children) {
-          var _iteratorNormalCompletion4 = true;
-          var _didIteratorError4 = false;
-          var _iteratorError4 = undefined;
+          if (expectation.children) {
+            var _iteratorNormalCompletion4 = true;
+            var _didIteratorError4 = false;
+            var _iteratorError4 = undefined;
 
-          try {
-            var _loop2 = function _loop2() {
-              var expectedEdge = _step4.value;
-              var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
-                return isEdge(edge, expectedEdge);
-              }; // Don't use assert with a custom message here. Otherwise the
-              // inspection in the message is done eagerly and wastes a lot of CPU
-              // time.
-
-              var hasChild = rootNodes.some(function (node) {
-                return node.edges.some(check);
-              });
-
-              if (!hasChild) {
-                throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
-              }
-            };
-
-            for (var _iterator4 = expectation.children[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-              _loop2();
-            }
-          } catch (err) {
-            _didIteratorError4 = true;
-            _iteratorError4 = err;
-          } finally {
             try {
-              if (!_iteratorNormalCompletion4 && _iterator4.return != null) {
-                _iterator4.return();
+              var _loop2 = function _loop2() {
+                var expectedEdge = _step4.value;
+                var check = typeof expectedEdge === 'function' ? expectedEdge : function (edge) {
+                  return isEdge(edge, expectedEdge);
+                }; // Don't use assert with a custom message here. Otherwise the
+                // inspection in the message is done eagerly and wastes a lot of CPU
+                // time.
+
+                var hasChild = rootNodes.some(function (node) {
+                  return node.edges.some(check);
+                });
+
+                if (!hasChild) {
+                  throw new Error('expected to find child ' + "".concat(util.inspect(expectedEdge), " in ").concat(inspectNode(rootNodes)));
+                }
+              };
+
+              for (var _iterator4 = expectation.children[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                _loop2();
               }
+            } catch (err) {
+              _didIteratorError4 = true;
+              _iteratorError4 = err;
             } finally {
-              if (_didIteratorError4) {
-                throw _iteratorError4;
+              try {
+                if (!_iteratorNormalCompletion4 && _iterator4.return != null) {
+                  _iterator4.return();
+                }
+              } finally {
+                if (_didIteratorError4) {
+                  throw _iteratorError4;
+                }
               }
             }
           }
         }
-      }
-    } catch (err) {
-      _didIteratorError3 = true;
-      _iteratorError3 = err;
-    } finally {
-      try {
-        if (!_iteratorNormalCompletion3 && _iterator3.return != null) {
-          _iterator3.return();
-        }
+      } catch (err) {
+        _didIteratorError3 = true;
+        _iteratorError3 = err;
       } finally {
-        if (_didIteratorError3) {
-          throw _iteratorError3;
+        try {
+          if (!_iteratorNormalCompletion3 && _iterator3.return != null) {
+            _iterator3.return();
+          }
+        } finally {
+          if (_didIteratorError3) {
+            throw _iteratorError3;
+          }
         }
       }
     }
-  };
+  }, {
+    key: "validateSnapshotNodes",
+    value: function validateSnapshotNodes(rootName, expected) {
+      var _ref4 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
+          _ref4$loose = _ref4.loose,
+          loose = _ref4$loose === void 0 ? false : _ref4$loose;
 
-  _proto.validateSnapshotNodes = function validateSnapshotNodes(rootName, expected) {
-    var _ref4 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
-        _ref4$loose = _ref4.loose,
-        loose = _ref4$loose === void 0 ? false : _ref4$loose;
-
-    this.validateSnapshot(rootName, expected, {
-      loose: loose
-    });
-    this.validateGraph(rootName, expected, {
-      loose: loose
-    });
-  };
+      this.validateSnapshot(rootName, expected, {
+        loose: loose
+      });
+      this.validateGraph(rootName, expected, {
+        loose: loose
+      });
+    }
+  }]);
 
   return State;
 }();

--- a/test/common/http2.js
+++ b/test/common/http2.js
@@ -1,6 +1,16 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
@@ -83,6 +93,8 @@ var Frame =
 /*#__PURE__*/
 function () {
   function Frame(length, type, flags, id) {
+    _classCallCheck(this, Frame);
+
     this[kFrameData] = Buffer.alloc(9);
     write24BE(this[kFrameData], 0, length);
     write8(this[kFrameData], 3, type);
@@ -103,13 +115,16 @@ function () {
 var SettingsFrame =
 /*#__PURE__*/
 function (_Frame) {
-  _inheritsLoose(SettingsFrame, _Frame);
+  _inherits(SettingsFrame, _Frame);
 
   function SettingsFrame() {
     var ack = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+
+    _classCallCheck(this, SettingsFrame);
+
     var flags = 0;
     if (ack) flags |= FLAG_ACK;
-    return _Frame.call(this, 0, 4, flags, 0) || this;
+    return _possibleConstructorReturn(this, _getPrototypeOf(SettingsFrame).call(this, 0, 4, flags, 0));
   }
 
   return SettingsFrame;
@@ -118,13 +133,16 @@ function (_Frame) {
 var DataFrame =
 /*#__PURE__*/
 function (_Frame2) {
-  _inheritsLoose(DataFrame, _Frame2);
+  _inherits(DataFrame, _Frame2);
 
   function DataFrame(id, payload) {
     var _this;
 
     var padlen = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
     var final = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+
+    _classCallCheck(this, DataFrame);
+
     var len = payload.length;
     var flags = 0;
     if (final) flags |= FLAG_EOS;
@@ -137,7 +155,7 @@ function (_Frame2) {
       flags |= FLAG_PADDED;
     }
 
-    _this = _Frame2.call(this, len, 0, flags, id) || this;
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(DataFrame).call(this, len, 0, flags, id));
     buffers.unshift(_this[kFrameData]);
     _this[kFrameData] = Buffer.concat(buffers);
     return _this;
@@ -149,13 +167,16 @@ function (_Frame2) {
 var HeadersFrame =
 /*#__PURE__*/
 function (_Frame3) {
-  _inheritsLoose(HeadersFrame, _Frame3);
+  _inherits(HeadersFrame, _Frame3);
 
   function HeadersFrame(id, payload) {
     var _this2;
 
     var padlen = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
     var final = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+
+    _classCallCheck(this, HeadersFrame);
+
     var len = payload.length;
     var flags = FLAG_EOH;
     if (final) flags |= FLAG_EOS;
@@ -168,7 +189,7 @@ function (_Frame3) {
       flags |= FLAG_PADDED;
     }
 
-    _this2 = _Frame3.call(this, len, 1, flags, id) || this;
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(HeadersFrame).call(this, len, 1, flags, id));
     buffers.unshift(_this2[kFrameData]);
     _this2[kFrameData] = Buffer.concat(buffers);
     return _this2;
@@ -180,14 +201,17 @@ function (_Frame3) {
 var PingFrame =
 /*#__PURE__*/
 function (_Frame4) {
-  _inheritsLoose(PingFrame, _Frame4);
+  _inherits(PingFrame, _Frame4);
 
   function PingFrame() {
     var _this3;
 
     var ack = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+
+    _classCallCheck(this, PingFrame);
+
     var buffers = [Buffer.alloc(8)];
-    _this3 = _Frame4.call(this, 8, 6, ack ? 1 : 0, 0) || this;
+    _this3 = _possibleConstructorReturn(this, _getPrototypeOf(PingFrame).call(this, 8, 6, ack ? 1 : 0, 0));
     buffers.unshift(_this3[kFrameData]);
     _this3[kFrameData] = Buffer.concat(buffers);
     return _this3;
@@ -199,13 +223,15 @@ function (_Frame4) {
 var AltSvcFrame =
 /*#__PURE__*/
 function (_Frame5) {
-  _inheritsLoose(AltSvcFrame, _Frame5);
+  _inherits(AltSvcFrame, _Frame5);
 
   function AltSvcFrame(size) {
     var _this4;
 
+    _classCallCheck(this, AltSvcFrame);
+
     var buffers = [Buffer.alloc(size)];
-    _this4 = _Frame5.call(this, size, 10, 0, 0) || this;
+    _this4 = _possibleConstructorReturn(this, _getPrototypeOf(AltSvcFrame).call(this, size, 10, 0, 0));
     buffers.unshift(_this4[kFrameData]);
     _this4[kFrameData] = Buffer.concat(buffers);
     return _this4;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
@@ -606,6 +608,8 @@ function expectWarning(nameOrMap, expected, code) {
 }
 
 var Comparison = function Comparison(obj, keys) {
+  _classCallCheck(this, Comparison);
+
   var _iteratorNormalCompletion2 = true;
   var _didIteratorError2 = false;
   var _iteratorError2 = undefined;

--- a/test/common/tls.js
+++ b/test/common/tls.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 /*<replacement>*/
 require('@babel/polyfill');
@@ -40,12 +54,14 @@ exports.ccs = Buffer.from('140303000101', 'hex');
 var TestTLSSocket =
 /*#__PURE__*/
 function (_net$Socket) {
-  _inheritsLoose(TestTLSSocket, _net$Socket);
+  _inherits(TestTLSSocket, _net$Socket);
 
   function TestTLSSocket(server_cert) {
     var _this;
 
-    _this = _net$Socket.call(this) || this;
+    _classCallCheck(this, TestTLSSocket);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TestTLSSocket).call(this));
     _this.server_cert = server_cert;
     _this.version = Buffer.from('0303', 'hex');
     _this.handshake_list = []; // AES128-GCM-SHA256
@@ -70,97 +86,104 @@ function (_net$Socket) {
     return _this;
   }
 
-  var _proto = TestTLSSocket.prototype;
+  _createClass(TestTLSSocket, [{
+    key: "createClientHello",
+    value: function createClientHello() {
+      var compressions = Buffer.from('0100', 'hex'); // null
 
-  _proto.createClientHello = function createClientHello() {
-    var compressions = Buffer.from('0100', 'hex'); // null
-
-    var msg = addHandshakeHeader(0x01, Buffer.concat([this.version, this.client_random, this.ciphers, compressions]));
-    this.emit('handshake', msg);
-    return addRecordHeader(0x16, msg);
-  };
-
-  _proto.createClientKeyExchange = function createClientKeyExchange() {
-    var encrypted_pre_master_secret = crypto.publicEncrypt({
-      key: this.server_cert,
-      padding: crypto.constants.RSA_PKCS1_PADDING
-    }, this.pre_master_secret);
-    var length = Buffer.alloc(2);
-    length.writeUIntBE(encrypted_pre_master_secret.length, 0, 2);
-    var msg = addHandshakeHeader(0x10, Buffer.concat([length, encrypted_pre_master_secret]));
-    this.emit('handshake', msg);
-    return addRecordHeader(0x16, msg);
-  };
-
-  _proto.createFinished = function createFinished() {
-    var shasum = crypto.createHash('sha256');
-    shasum.update(Buffer.concat(this.handshake_list));
-    var message_hash = shasum.digest();
-    var r = PRF12('sha256', this.master_secret, 'client finished', message_hash, 12);
-    var msg = addHandshakeHeader(0x14, r);
-    this.emit('handshake', msg);
-    return addRecordHeader(0x16, msg);
-  };
-
-  _proto.createIllegalHandshake = function createIllegalHandshake() {
-    var illegal_handshake = Buffer.alloc(5);
-    return addRecordHeader(0x16, illegal_handshake);
-  };
-
-  _proto.parseTLSFrame = function parseTLSFrame(buf) {
-    var offset = 0;
-    var record = buf.slice(offset, 5);
-    var type = record[0];
-    var length = record.slice(3, 5).readUInt16BE(0);
-    offset += 5;
-    var remaining = buf.slice(offset, offset + length);
-
-    if (type === 0x16) {
-      do {
-        remaining = this.parseTLSHandshake(remaining);
-      } while (remaining.length > 0);
+      var msg = addHandshakeHeader(0x01, Buffer.concat([this.version, this.client_random, this.ciphers, compressions]));
+      this.emit('handshake', msg);
+      return addRecordHeader(0x16, msg);
     }
-
-    offset += length;
-    return buf.slice(offset);
-  };
-
-  _proto.parseTLSHandshake = function parseTLSHandshake(buf) {
-    var offset = 0;
-    var handshake_type = buf[offset];
-
-    if (handshake_type === 0x02) {
-      var server_random = buf.slice(6, 6 + 32);
-      this.emit('server_random', server_random);
+  }, {
+    key: "createClientKeyExchange",
+    value: function createClientKeyExchange() {
+      var encrypted_pre_master_secret = crypto.publicEncrypt({
+        key: this.server_cert,
+        padding: crypto.constants.RSA_PKCS1_PADDING
+      }, this.pre_master_secret);
+      var length = Buffer.alloc(2);
+      length.writeUIntBE(encrypted_pre_master_secret.length, 0, 2);
+      var msg = addHandshakeHeader(0x10, Buffer.concat([length, encrypted_pre_master_secret]));
+      this.emit('handshake', msg);
+      return addRecordHeader(0x16, msg);
     }
+  }, {
+    key: "createFinished",
+    value: function createFinished() {
+      var shasum = crypto.createHash('sha256');
+      shasum.update(Buffer.concat(this.handshake_list));
+      var message_hash = shasum.digest();
+      var r = PRF12('sha256', this.master_secret, 'client finished', message_hash, 12);
+      var msg = addHandshakeHeader(0x14, r);
+      this.emit('handshake', msg);
+      return addRecordHeader(0x16, msg);
+    }
+  }, {
+    key: "createIllegalHandshake",
+    value: function createIllegalHandshake() {
+      var illegal_handshake = Buffer.alloc(5);
+      return addRecordHeader(0x16, illegal_handshake);
+    }
+  }, {
+    key: "parseTLSFrame",
+    value: function parseTLSFrame(buf) {
+      var offset = 0;
+      var record = buf.slice(offset, 5);
+      var type = record[0];
+      var length = record.slice(3, 5).readUInt16BE(0);
+      offset += 5;
+      var remaining = buf.slice(offset, offset + length);
 
-    offset += 1;
-    var length = buf.readUIntBE(offset, 3);
-    offset += 3;
-    var handshake = buf.slice(0, offset + length);
-    this.emit('handshake', handshake);
-    offset += length;
-    var remaining = buf.slice(offset);
-    return remaining;
-  };
+      if (type === 0x16) {
+        do {
+          remaining = this.parseTLSHandshake(remaining);
+        } while (remaining.length > 0);
+      }
 
-  _proto.encrypt = function encrypt(plain) {
-    var type = plain.slice(0, 1);
-    var version = plain.slice(1, 3);
-    var nonce = crypto.randomBytes(8);
-    var iv = Buffer.concat([this.client_writeIV.slice(0, 4), nonce]);
-    var bob = crypto.createCipheriv('aes-128-gcm', this.client_writeKey, iv);
-    var write_seq = Buffer.alloc(8);
-    write_seq.writeUInt32BE(this.write_seq++, 4);
-    var aad = Buffer.concat([write_seq, plain.slice(0, 5)]);
-    bob.setAAD(aad);
-    var encrypted1 = bob.update(plain.slice(5));
-    var encrypted = Buffer.concat([encrypted1, bob.final()]);
-    var tag = bob.getAuthTag();
-    var length = Buffer.alloc(2);
-    length.writeUInt16BE(nonce.length + encrypted.length + tag.length, 0);
-    return Buffer.concat([type, version, length, nonce, encrypted, tag]);
-  };
+      offset += length;
+      return buf.slice(offset);
+    }
+  }, {
+    key: "parseTLSHandshake",
+    value: function parseTLSHandshake(buf) {
+      var offset = 0;
+      var handshake_type = buf[offset];
+
+      if (handshake_type === 0x02) {
+        var server_random = buf.slice(6, 6 + 32);
+        this.emit('server_random', server_random);
+      }
+
+      offset += 1;
+      var length = buf.readUIntBE(offset, 3);
+      offset += 3;
+      var handshake = buf.slice(0, offset + length);
+      this.emit('handshake', handshake);
+      offset += length;
+      var remaining = buf.slice(offset);
+      return remaining;
+    }
+  }, {
+    key: "encrypt",
+    value: function encrypt(plain) {
+      var type = plain.slice(0, 1);
+      var version = plain.slice(1, 3);
+      var nonce = crypto.randomBytes(8);
+      var iv = Buffer.concat([this.client_writeIV.slice(0, 4), nonce]);
+      var bob = crypto.createCipheriv('aes-128-gcm', this.client_writeKey, iv);
+      var write_seq = Buffer.alloc(8);
+      write_seq.writeUInt32BE(this.write_seq++, 4);
+      var aad = Buffer.concat([write_seq, plain.slice(0, 5)]);
+      bob.setAAD(aad);
+      var encrypted1 = bob.update(plain.slice(5));
+      var encrypted = Buffer.concat([encrypted1, bob.final()]);
+      var tag = bob.getAuthTag();
+      var length = Buffer.alloc(2);
+      length.writeUInt16BE(nonce.length + encrypted.length + tag.length, 0);
+      return Buffer.concat([type, version, length, nonce, encrypted, tag]);
+    }
+  }]);
 
   return TestTLSSocket;
 }(net.Socket);

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -39,22 +53,25 @@ var passed = false;
 var TestStream =
 /*#__PURE__*/
 function (_stream$Transform) {
-  _inheritsLoose(TestStream, _stream$Transform);
+  _inherits(TestStream, _stream$Transform);
 
   function TestStream() {
-    return _stream$Transform.apply(this, arguments) || this;
+    _classCallCheck(this, TestStream);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(TestStream).apply(this, arguments));
   }
 
-  var _proto = TestStream.prototype;
+  _createClass(TestStream, [{
+    key: "_transform",
+    value: function _transform(chunk, encoding, done) {
+      if (!passed) {
+        // Char 'a' only exists in the last write
+        passed = chunk.toString().includes('a');
+      }
 
-  _proto._transform = function _transform(chunk, encoding, done) {
-    if (!passed) {
-      // Char 'a' only exists in the last write
-      passed = chunk.toString().includes('a');
+      done();
     }
-
-    done();
-  };
+  }]);
 
   return TestStream;
 }(stream.Transform);

--- a/test/parallel/test-stream-events-prepend.js
+++ b/test/parallel/test-stream-events-prepend.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 /*<replacement>*/
 var bufferShim = require('safe-buffer').Buffer;
@@ -14,21 +28,24 @@ var stream = require('../../');
 var Writable =
 /*#__PURE__*/
 function (_stream$Writable) {
-  _inheritsLoose(Writable, _stream$Writable);
+  _inherits(Writable, _stream$Writable);
 
   function Writable() {
     var _this;
 
-    _this = _stream$Writable.call(this) || this;
+    _classCallCheck(this, Writable);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Writable).call(this));
     _this.prependListener = undefined;
     return _this;
   }
 
-  var _proto = Writable.prototype;
-
-  _proto._write = function _write(chunk, end, cb) {
-    cb();
-  };
+  _createClass(Writable, [{
+    key: "_write",
+    value: function _write(chunk, end, cb) {
+      cb();
+    }
+  }]);
 
   return Writable;
 }(stream.Writable);
@@ -36,17 +53,20 @@ function (_stream$Writable) {
 var Readable =
 /*#__PURE__*/
 function (_stream$Readable) {
-  _inheritsLoose(Readable, _stream$Readable);
+  _inherits(Readable, _stream$Readable);
 
   function Readable() {
-    return _stream$Readable.apply(this, arguments) || this;
+    _classCallCheck(this, Readable);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Readable).apply(this, arguments));
   }
 
-  var _proto2 = Readable.prototype;
-
-  _proto2._read = function _read() {
-    this.push(null);
-  };
+  _createClass(Readable, [{
+    key: "_read",
+    value: function _read() {
+      this.push(null);
+    }
+  }]);
 
   return Readable;
 }(stream.Readable);

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -39,23 +53,26 @@ var Writable = require('../../lib/_stream_writable');
 var TestReadable =
 /*#__PURE__*/
 function (_Readable) {
-  _inheritsLoose(TestReadable, _Readable);
+  _inherits(TestReadable, _Readable);
 
   function TestReadable(opt) {
     var _this;
 
-    _this = _Readable.call(this, opt) || this;
+    _classCallCheck(this, TestReadable);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TestReadable).call(this, opt));
     _this._ended = false;
     return _this;
   }
 
-  var _proto = TestReadable.prototype;
-
-  _proto._read = function _read() {
-    if (this._ended) this.emit('error', new Error('_read called twice'));
-    this._ended = true;
-    this.push(null);
-  };
+  _createClass(TestReadable, [{
+    key: "_read",
+    value: function _read() {
+      if (this._ended) this.emit('error', new Error('_read called twice'));
+      this._ended = true;
+      this.push(null);
+    }
+  }]);
 
   return TestReadable;
 }(Readable);
@@ -63,23 +80,26 @@ function (_Readable) {
 var TestWritable =
 /*#__PURE__*/
 function (_Writable) {
-  _inheritsLoose(TestWritable, _Writable);
+  _inherits(TestWritable, _Writable);
 
   function TestWritable(opt) {
     var _this2;
 
-    _this2 = _Writable.call(this, opt) || this;
+    _classCallCheck(this, TestWritable);
+
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(TestWritable).call(this, opt));
     _this2._written = [];
     return _this2;
   }
 
-  var _proto2 = TestWritable.prototype;
+  _createClass(TestWritable, [{
+    key: "_write",
+    value: function _write(chunk, encoding, cb) {
+      this._written.push(chunk);
 
-  _proto2._write = function _write(chunk, encoding, cb) {
-    this._written.push(chunk);
-
-    cb();
-  };
+      cb();
+    }
+  }]);
 
   return TestWritable;
 }(Writable); // this one should not emit 'end' until we read() from it later.

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -37,42 +51,45 @@ var Readable = require('../../').Readable;
 var MyStream =
 /*#__PURE__*/
 function (_Readable) {
-  _inheritsLoose(MyStream, _Readable);
+  _inherits(MyStream, _Readable);
 
   function MyStream(options) {
     var _this;
 
-    _this = _Readable.call(this, options) || this;
+    _classCallCheck(this, MyStream);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(MyStream).call(this, options));
     _this._chunks = 3;
     return _this;
   }
 
-  var _proto = MyStream.prototype;
+  _createClass(MyStream, [{
+    key: "_read",
+    value: function _read(n) {
+      var _this2 = this;
 
-  _proto._read = function _read(n) {
-    var _this2 = this;
+      switch (this._chunks--) {
+        case 0:
+          return this.push(null);
 
-    switch (this._chunks--) {
-      case 0:
-        return this.push(null);
+        case 1:
+          return setTimeout(function () {
+            _this2.push('last chunk');
+          }, 100);
 
-      case 1:
-        return setTimeout(function () {
-          _this2.push('last chunk');
-        }, 100);
+        case 2:
+          return this.push('second to last chunk');
 
-      case 2:
-        return this.push('second to last chunk');
+        case 3:
+          return process.nextTick(function () {
+            _this2.push('first chunk');
+          });
 
-      case 3:
-        return process.nextTick(function () {
-          _this2.push('first chunk');
-        });
-
-      default:
-        throw new Error('?');
+        default:
+          throw new Error('?');
+      }
     }
-  };
+  }]);
 
   return MyStream;
 }(Readable);

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -215,7 +215,7 @@ function _tests() {
         var success = false;
         f().then(function () {
           success = true;
-          throw new Error('should not succeeed');
+          throw new Error('should not succeed');
         }).catch(function (e2) {
           if (success) {
             throw e2;

--- a/test/parallel/test-stream-unpipe-event.js
+++ b/test/parallel/test-stream-unpipe-event.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 if (process.version.indexOf('v0.8') === 0) {
   process.exit(0);
@@ -23,17 +37,20 @@ var _require = require('../../'),
 var NullWriteable =
 /*#__PURE__*/
 function (_Writable) {
-  _inheritsLoose(NullWriteable, _Writable);
+  _inherits(NullWriteable, _Writable);
 
   function NullWriteable() {
-    return _Writable.apply(this, arguments) || this;
+    _classCallCheck(this, NullWriteable);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(NullWriteable).apply(this, arguments));
   }
 
-  var _proto = NullWriteable.prototype;
-
-  _proto._write = function _write(chunk, encoding, callback) {
-    return callback();
-  };
+  _createClass(NullWriteable, [{
+    key: "_write",
+    value: function _write(chunk, encoding, callback) {
+      return callback();
+    }
+  }]);
 
   return NullWriteable;
 }(Writable);
@@ -41,17 +58,20 @@ function (_Writable) {
 var QuickEndReadable =
 /*#__PURE__*/
 function (_Readable) {
-  _inheritsLoose(QuickEndReadable, _Readable);
+  _inherits(QuickEndReadable, _Readable);
 
   function QuickEndReadable() {
-    return _Readable.apply(this, arguments) || this;
+    _classCallCheck(this, QuickEndReadable);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(QuickEndReadable).apply(this, arguments));
   }
 
-  var _proto2 = QuickEndReadable.prototype;
-
-  _proto2._read = function _read() {
-    this.push(null);
-  };
+  _createClass(QuickEndReadable, [{
+    key: "_read",
+    value: function _read() {
+      this.push(null);
+    }
+  }]);
 
   return QuickEndReadable;
 }(Readable);
@@ -59,15 +79,18 @@ function (_Readable) {
 var NeverEndReadable =
 /*#__PURE__*/
 function (_Readable2) {
-  _inheritsLoose(NeverEndReadable, _Readable2);
+  _inherits(NeverEndReadable, _Readable2);
 
   function NeverEndReadable() {
-    return _Readable2.apply(this, arguments) || this;
+    _classCallCheck(this, NeverEndReadable);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(NeverEndReadable).apply(this, arguments));
   }
 
-  var _proto3 = NeverEndReadable.prototype;
-
-  _proto3._read = function _read() {};
+  _createClass(NeverEndReadable, [{
+    key: "_read",
+    value: function _read() {}
+  }]);
 
   return NeverEndReadable;
 }(Readable);

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -37,22 +51,25 @@ var stream = require('../../');
 var MyWritable =
 /*#__PURE__*/
 function (_stream$Writable) {
-  _inheritsLoose(MyWritable, _stream$Writable);
+  _inherits(MyWritable, _stream$Writable);
 
   function MyWritable(fn, options) {
     var _this;
 
-    _this = _stream$Writable.call(this, options) || this;
+    _classCallCheck(this, MyWritable);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(MyWritable).call(this, options));
     _this.fn = fn;
     return _this;
   }
 
-  var _proto = MyWritable.prototype;
-
-  _proto._write = function _write(chunk, encoding, callback) {
-    this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
-    callback();
-  };
+  _createClass(MyWritable, [{
+    key: "_write",
+    value: function _write(chunk, encoding, callback) {
+      this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+      callback();
+    }
+  }]);
 
   return MyWritable;
 }(stream.Writable);

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -37,22 +51,25 @@ var stream = require('../../');
 var MyWritable =
 /*#__PURE__*/
 function (_stream$Writable) {
-  _inheritsLoose(MyWritable, _stream$Writable);
+  _inherits(MyWritable, _stream$Writable);
 
   function MyWritable(fn, options) {
     var _this;
 
-    _this = _stream$Writable.call(this, options) || this;
+    _classCallCheck(this, MyWritable);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(MyWritable).call(this, options));
     _this.fn = fn;
     return _this;
   }
 
-  var _proto = MyWritable.prototype;
-
-  _proto._write = function _write(chunk, encoding, callback) {
-    this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
-    callback();
-  };
+  _createClass(MyWritable, [{
+    key: "_write",
+    value: function _write(chunk, encoding, callback) {
+      this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+      callback();
+    }
+  }]);
 
   return MyWritable;
 }(stream.Writable);

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 /*<replacement>*/
 var bufferShim = require('safe-buffer').Buffer;
@@ -16,18 +30,21 @@ var stream = require('../../');
 var MyWritable =
 /*#__PURE__*/
 function (_stream$Writable) {
-  _inheritsLoose(MyWritable, _stream$Writable);
+  _inherits(MyWritable, _stream$Writable);
 
   function MyWritable() {
-    return _stream$Writable.apply(this, arguments) || this;
+    _classCallCheck(this, MyWritable);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(MyWritable).apply(this, arguments));
   }
 
-  var _proto = MyWritable.prototype;
-
-  _proto._write = function _write(chunk, encoding, callback) {
-    assert.notStrictEqual(chunk, null);
-    callback();
-  };
+  _createClass(MyWritable, [{
+    key: "_write",
+    value: function _write(chunk, encoding, callback) {
+      assert.notStrictEqual(chunk, null);
+      callback();
+    }
+  }]);
 
   return MyWritable;
 }(stream.Writable);

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -39,52 +53,55 @@ var EE = require('events').EventEmitter;
 var TestReader =
 /*#__PURE__*/
 function (_R) {
-  _inheritsLoose(TestReader, _R);
+  _inherits(TestReader, _R);
 
   function TestReader(n) {
     var _this;
 
-    _this = _R.call(this) || this;
+    _classCallCheck(this, TestReader);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TestReader).call(this));
     _this._buffer = bufferShim.alloc(n || 100, 'x');
     _this._pos = 0;
     _this._bufs = 10;
     return _this;
   }
 
-  var _proto = TestReader.prototype;
+  _createClass(TestReader, [{
+    key: "_read",
+    value: function _read(n) {
+      var _this2 = this;
 
-  _proto._read = function _read(n) {
-    var _this2 = this;
+      var max = this._buffer.length - this._pos;
+      n = Math.max(n, 0);
+      var toRead = Math.min(n, max);
 
-    var max = this._buffer.length - this._pos;
-    n = Math.max(n, 0);
-    var toRead = Math.min(n, max);
+      if (toRead === 0) {
+        // simulate the read buffer filling up with some more bytes some time
+        // in the future.
+        setTimeout(function () {
+          _this2._pos = 0;
+          _this2._bufs -= 1;
 
-    if (toRead === 0) {
-      // simulate the read buffer filling up with some more bytes some time
-      // in the future.
-      setTimeout(function () {
-        _this2._pos = 0;
-        _this2._bufs -= 1;
+          if (_this2._bufs <= 0) {
+            // read them all!
+            if (!_this2.ended) _this2.push(null);
+          } else {
+            // now we have more.
+            // kinda cheating by calling _read, but whatever,
+            // it's just fake anyway.
+            _this2._read(n);
+          }
+        }, 10);
+        return;
+      }
 
-        if (_this2._bufs <= 0) {
-          // read them all!
-          if (!_this2.ended) _this2.push(null);
-        } else {
-          // now we have more.
-          // kinda cheating by calling _read, but whatever,
-          // it's just fake anyway.
-          _this2._read(n);
-        }
-      }, 10);
-      return;
+      var ret = this._buffer.slice(this._pos, this._pos + toRead);
+
+      this._pos += toRead;
+      this.push(ret);
     }
-
-    var ret = this._buffer.slice(this._pos, this._pos + toRead);
-
-    this._pos += toRead;
-    this.push(ret);
-  };
+  }]);
 
   return TestReader;
 }(R);
@@ -92,29 +109,33 @@ function (_R) {
 var TestWriter =
 /*#__PURE__*/
 function (_EE) {
-  _inheritsLoose(TestWriter, _EE);
+  _inherits(TestWriter, _EE);
 
   function TestWriter() {
     var _this3;
 
-    _this3 = _EE.call(this) || this;
+    _classCallCheck(this, TestWriter);
+
+    _this3 = _possibleConstructorReturn(this, _getPrototypeOf(TestWriter).call(this));
     _this3.received = [];
     _this3.flush = false;
     return _this3;
   }
 
-  var _proto2 = TestWriter.prototype;
-
-  _proto2.write = function write(c) {
-    this.received.push(c.toString());
-    this.emit('write', c);
-    return true;
-  };
-
-  _proto2.end = function end(c) {
-    if (c) this.write(c);
-    this.emit('end', this.received);
-  };
+  _createClass(TestWriter, [{
+    key: "write",
+    value: function write(c) {
+      this.received.push(c.toString());
+      this.emit('write', c);
+      return true;
+    }
+  }, {
+    key: "end",
+    value: function end(c) {
+      if (c) this.write(c);
+      this.emit('end', this.received);
+    }
+  }]);
 
   return TestWriter;
 }(EE);

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -41,12 +55,14 @@ var ondataCalled = 0;
 var TestReader =
 /*#__PURE__*/
 function (_R) {
-  _inheritsLoose(TestReader, _R);
+  _inherits(TestReader, _R);
 
   function TestReader() {
     var _this;
 
-    _this = _R.call(this) || this;
+    _classCallCheck(this, TestReader);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TestReader).call(this));
     _this._buffer = bufferShim.alloc(100, 'x');
 
     _this.on('data', function () {
@@ -56,12 +72,13 @@ function (_R) {
     return _this;
   }
 
-  var _proto = TestReader.prototype;
-
-  _proto._read = function _read(n) {
-    this.push(this._buffer);
-    this._buffer = bufferShim.alloc(0);
-  };
+  _createClass(TestReader, [{
+    key: "_read",
+    value: function _read(n) {
+      this.push(this._buffer);
+      this._buffer = bufferShim.alloc(0);
+    }
+  }]);
 
   return TestReader;
 }(R);
@@ -78,12 +95,14 @@ setImmediate(function () {
 var TestWriter =
 /*#__PURE__*/
 function (_W) {
-  _inheritsLoose(TestWriter, _W);
+  _inherits(TestWriter, _W);
 
   function TestWriter() {
     var _this2;
 
-    _this2 = _W.call(this) || this;
+    _classCallCheck(this, TestWriter);
+
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(TestWriter).call(this));
 
     _this2.write('foo');
 
@@ -92,11 +111,12 @@ function (_W) {
     return _this2;
   }
 
-  var _proto2 = TestWriter.prototype;
-
-  _proto2._write = function _write(chunk, enc, cb) {
-    cb();
-  };
+  _createClass(TestWriter, [{
+    key: "_write",
+    value: function _write(chunk, enc, cb) {
+      cb();
+    }
+  }]);
 
   return TestWriter;
 }(W);

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -35,18 +49,21 @@ var stream = require('../../');
 var Read =
 /*#__PURE__*/
 function (_stream$Readable) {
-  _inheritsLoose(Read, _stream$Readable);
+  _inherits(Read, _stream$Readable);
 
   function Read() {
-    return _stream$Readable.apply(this, arguments) || this;
+    _classCallCheck(this, Read);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Read).apply(this, arguments));
   }
 
-  var _proto = Read.prototype;
-
-  _proto._read = function _read(size) {
-    this.push('x');
-    this.push(null);
-  };
+  _createClass(Read, [{
+    key: "_read",
+    value: function _read(size) {
+      this.push('x');
+      this.push(null);
+    }
+  }]);
 
   return Read;
 }(stream.Readable);
@@ -54,18 +71,21 @@ function (_stream$Readable) {
 var Write =
 /*#__PURE__*/
 function (_stream$Writable) {
-  _inheritsLoose(Write, _stream$Writable);
+  _inherits(Write, _stream$Writable);
 
   function Write() {
-    return _stream$Writable.apply(this, arguments) || this;
+    _classCallCheck(this, Write);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Write).apply(this, arguments));
   }
 
-  var _proto2 = Write.prototype;
-
-  _proto2._write = function _write(buffer, encoding, cb) {
-    this.emit('error', new Error('boom'));
-    this.emit('alldone');
-  };
+  _createClass(Write, [{
+    key: "_write",
+    value: function _write(buffer, encoding, cb) {
+      this.emit('error', new Error('boom'));
+      this.emit('alldone');
+    }
+  }]);
 
   return Write;
 }(stream.Writable);

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -37,44 +51,47 @@ var R = require('../../lib/_stream_readable');
 var TestReader =
 /*#__PURE__*/
 function (_R) {
-  _inheritsLoose(TestReader, _R);
+  _inherits(TestReader, _R);
 
   function TestReader(n, opts) {
     var _this;
 
-    _this = _R.call(this, opts) || this;
+    _classCallCheck(this, TestReader);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TestReader).call(this, opts));
     _this.pos = 0;
     _this.len = n || 100;
     return _this;
   }
 
-  var _proto = TestReader.prototype;
+  _createClass(TestReader, [{
+    key: "_read",
+    value: function _read(n) {
+      var _this2 = this;
 
-  _proto._read = function _read(n) {
-    var _this2 = this;
+      setTimeout(function () {
+        if (_this2.pos >= _this2.len) {
+          // double push(null) to test eos handling
+          _this2.push(null);
 
-    setTimeout(function () {
-      if (_this2.pos >= _this2.len) {
-        // double push(null) to test eos handling
-        _this2.push(null);
+          return _this2.push(null);
+        }
 
-        return _this2.push(null);
-      }
+        n = Math.min(n, _this2.len - _this2.pos);
 
-      n = Math.min(n, _this2.len - _this2.pos);
+        if (n <= 0) {
+          // double push(null) to test eos handling
+          _this2.push(null);
 
-      if (n <= 0) {
-        // double push(null) to test eos handling
-        _this2.push(null);
+          return _this2.push(null);
+        }
 
-        return _this2.push(null);
-      }
-
-      _this2.pos += n;
-      var ret = bufferShim.alloc(n, 'a');
-      return _this2.push(ret);
-    }, 1);
-  };
+        _this2.pos += n;
+        var ret = bufferShim.alloc(n, 'a');
+        return _this2.push(ret);
+      }, 1);
+    }
+  }]);
 
   return TestReader;
 }(R);

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 (function () {
   // Copyright Joyent, Inc. and other Node contributors.
@@ -38,17 +52,20 @@ function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.crea
   var TestWriter =
   /*#__PURE__*/
   function (_stream$Writable) {
-    _inheritsLoose(TestWriter, _stream$Writable);
+    _inherits(TestWriter, _stream$Writable);
 
     function TestWriter() {
-      return _stream$Writable.apply(this, arguments) || this;
+      _classCallCheck(this, TestWriter);
+
+      return _possibleConstructorReturn(this, _getPrototypeOf(TestWriter).apply(this, arguments));
     }
 
-    var _proto = TestWriter.prototype;
-
-    _proto._write = function _write(buffer, encoding, callback) {
-      console.log('write called'); // super slow write stream (callback never called)
-    };
+    _createClass(TestWriter, [{
+      key: "_write",
+      value: function _write(buffer, encoding, callback) {
+        console.log('write called'); // super slow write stream (callback never called)
+      }
+    }]);
 
     return TestWriter;
   }(stream.Writable);
@@ -58,22 +75,25 @@ function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.crea
   var TestReader =
   /*#__PURE__*/
   function (_stream$Readable) {
-    _inheritsLoose(TestReader, _stream$Readable);
+    _inherits(TestReader, _stream$Readable);
 
     function TestReader() {
       var _this;
 
-      _this = _stream$Readable.call(this) || this;
+      _classCallCheck(this, TestReader);
+
+      _this = _possibleConstructorReturn(this, _getPrototypeOf(TestReader).call(this));
       _this.reads = 0;
       return _this;
     }
 
-    var _proto2 = TestReader.prototype;
-
-    _proto2._read = function _read(size) {
-      this.reads += 1;
-      this.push(bufferShim.alloc(size));
-    };
+    _createClass(TestReader, [{
+      key: "_read",
+      value: function _read(size) {
+        this.reads += 1;
+        this.push(bufferShim.alloc(size));
+      }
+    }]);
 
     return TestReader;
   }(stream.Readable);

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -39,17 +53,20 @@ var chunk = bufferShim.from('hallo');
 var TestWriter =
 /*#__PURE__*/
 function (_stream$Writable) {
-  _inheritsLoose(TestWriter, _stream$Writable);
+  _inherits(TestWriter, _stream$Writable);
 
   function TestWriter() {
-    return _stream$Writable.apply(this, arguments) || this;
+    _classCallCheck(this, TestWriter);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(TestWriter).apply(this, arguments));
   }
 
-  var _proto = TestWriter.prototype;
-
-  _proto._write = function _write(buffer, encoding, callback) {
-    callback(null);
-  };
+  _createClass(TestWriter, [{
+    key: "_write",
+    value: function _write(buffer, encoding, callback) {
+      callback(null);
+    }
+  }]);
 
   return TestWriter;
 }(stream.Writable);
@@ -60,19 +77,22 @@ var dest = new TestWriter(); // Set this high so that we'd trigger a nextTick wa
 var TestReader =
 /*#__PURE__*/
 function (_stream$Readable) {
-  _inheritsLoose(TestReader, _stream$Readable);
+  _inherits(TestReader, _stream$Readable);
 
   function TestReader() {
-    return _stream$Readable.call(this, {
+    _classCallCheck(this, TestReader);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(TestReader).call(this, {
       highWaterMark: 0x10000
-    }) || this;
+    }));
   }
 
-  var _proto2 = TestReader.prototype;
-
-  _proto2._read = function _read(size) {
-    this.push(chunk);
-  };
+  _createClass(TestReader, [{
+    key: "_read",
+    value: function _read(size) {
+      this.push(chunk);
+    }
+  }]);
 
   return TestReader;
 }(stream.Readable);

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -1,6 +1,20 @@
 "use strict";
 
-function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (typeof call === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -39,30 +53,33 @@ var assert = require('assert/');
 var TestWriter =
 /*#__PURE__*/
 function (_W) {
-  _inheritsLoose(TestWriter, _W);
+  _inherits(TestWriter, _W);
 
   function TestWriter(opts) {
     var _this;
 
-    _this = _W.call(this, opts) || this;
+    _classCallCheck(this, TestWriter);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TestWriter).call(this, opts));
     _this.buffer = [];
     _this.written = 0;
     return _this;
   }
 
-  var _proto = TestWriter.prototype;
+  _createClass(TestWriter, [{
+    key: "_write",
+    value: function _write(chunk, encoding, cb) {
+      var _this2 = this;
 
-  _proto._write = function _write(chunk, encoding, cb) {
-    var _this2 = this;
+      // simulate a small unpredictable latency
+      setTimeout(function () {
+        _this2.buffer.push(chunk.toString());
 
-    // simulate a small unpredictable latency
-    setTimeout(function () {
-      _this2.buffer.push(chunk.toString());
-
-      _this2.written += chunk.length;
-      cb();
-    }, Math.floor(Math.random() * 10));
-  };
+        _this2.written += chunk.length;
+        cb();
+      }, Math.floor(Math.random() * 10));
+    }
+  }]);
 
   return TestWriter;
 }(W);


### PR DESCRIPTION
```js
Object.defineProperty(Object.prototype, util.inspect.custom, {
  set(v) { throw 'this should not happen inside readable-stream'; }
});
```

With this change, I believe the output will use [[Define]] instead of [[Set]] for https://github.com/nodejs/node/blob/c101251a95cc82142bee4637f8db6cc360a06d82/lib/internal/streams/buffer_list.js#L167, and thus no longer fail when Object.prototype is modified.