### PR TITLE
Upgrade airtap and use GitHub Actions

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,17 +1,18 @@
-sauce_connect: true
+providers:
+  - airtap-sauce
+
 browsers:
   - name: chrome
-    version: latest
-    platform: Windows 10
-  - name: internet explorer
-    version: latest
-    platform: Windows 10
+  - name: ie
   - name: firefox
-    version: latest
-    platform: Windows 10
   - name: safari
-    version: latest
-    platform: Mac 10.13
-  - name: microsoftedge
-    version: latest
-    platform: Windows 10
+  - name: edge
+
+presets:
+  local:
+    providers:
+      - airtap-playwright
+    browsers:
+      - name: chromium
+      - name: firefox
+      - name: webkit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions CI
+name: Node.js
 
 on: [push, pull_request]
 

--- a/.github/workflows/sauce.yml
+++ b/.github/workflows/sauce.yml
@@ -1,0 +1,24 @@
+name: Sauce Labs
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install
+        run: npm install
+        env:
+          # Download Sauce Connect binary now instead of on first run
+          SAUCE_CONNECT_DOWNLOAD_ON_INSTALL: true
+      - name: Add host
+        run: echo "127.0.0.1 airtap.local" | sudo tee -a /etc/hosts
+      - name: Test
+        run: npm run test-browsers
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/sauce.yml
+++ b/.github/workflows/sauce.yml
@@ -17,8 +17,15 @@ jobs:
           SAUCE_CONNECT_DOWNLOAD_ON_INSTALL: true
       - name: Add host
         run: echo "127.0.0.1 airtap.local" | sudo tee -a /etc/hosts
+      - name: Verify Sauce Connect
+        run: ./node_modules/sauce-connect-launcher/sc/sc-4.6.2-linux/bin/sc --doctor || echo Bad
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       - name: Test
         run: npm run test-browsers
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          DEBUG: airtap*
+          DEBUG_COLORS: true

--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,6 @@ zlib.js
 .babelrc
 .travis.yml
 .nyc_output
+.github
 coverage
 doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,3 @@ notifications:
 
 import:
   - nodejs/ci-config-travis:lts/gte-6.yml
-
-env:
-  - CMD=test
-
-jobs:
-  fast_finish: true
-  include:
-    - node_js: lts/*
-      env: CMD=test-browsers
-      addons:
-        sauce_connect: true
-        hosts:
-        - airtap.local
-
-script: npm run $CMD

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-env": "^7.2.0",
     "airtap": "^4.0.1",
     "airtap-playwright": "^1.0.1",
-    "airtap-sauce": "^1.0.0",
+    "airtap-sauce": "^1.1.0",
     "assert": "^1.4.0",
     "bl": "^2.0.0",
     "deep-strict-equal": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "@babel/core": "^7.2.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.2.0",
-    "airtap": "0.0.9",
+    "airtap": "^4.0.1",
+    "airtap-playwright": "^1.0.1",
+    "airtap-sauce": "^1.0.0",
     "assert": "^1.4.0",
     "bl": "^2.0.0",
     "deep-strict-equal": "^0.2.0",
@@ -36,8 +38,8 @@
   "scripts": {
     "test": "tap -J --no-esm test/parallel/*.js test/ours/*.js",
     "ci": "TAP=1 tap --no-esm test/parallel/*.js test/ours/*.js | tee test.tap",
-    "test-browsers": "airtap --sauce-connect --loopback airtap.local -- test/browser.js",
-    "test-browser-local": "airtap --open --local -- test/browser.js",
+    "test-browsers": "airtap test/browser.js",
+    "test-browsers-local": "airtap -p local test/browser.js",
     "cover": "nyc npm test",
     "report": "nyc report --reporter=lcov",
     "update-browser-errors": "babel -o errors-browser.js errors.js"


### PR DESCRIPTION
- Upgrade airtap to v4 (see its [upgrade guide](https://github.com/airtap/airtap/blob/master/UPGRADING.md))
- Move Sauce Labs tests from Travis to GitHub Actions
- Use playwright for headless local testing

Complements #418.