### PR TITLE
Don't assign to readonly `promises` property when `READABLE_STREAM === 'disable'`

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -3,7 +3,7 @@ if (process.env.READABLE_STREAM === 'disable' && Stream) {
   module.exports = Stream.Readable;
   Object.entries(Object.getOwnPropertyDescriptors(Stream))
     .filter((entry) => entry[1].writable && entry[0] !== 'prototype')
-    .forEach((entry) => module.exports[entry[0]] = Stream[entry[0]])
+    .forEach((entry) => module.exports[entry[0]] = Stream[entry[0]]);
   module.exports.Stream = Stream;
 } else {
   exports = module.exports = require('./lib/_stream_readable.js');

--- a/readable.js
+++ b/readable.js
@@ -1,7 +1,9 @@
 var Stream = require('stream');
 if (process.env.READABLE_STREAM === 'disable' && Stream) {
   module.exports = Stream.Readable;
-  Object.assign(module.exports, Stream);
+  Object.entries(Object.getOwnPropertyDescriptors(Stream))
+    .filter((entry) => entry[1].writable && entry[0] !== 'prototype')
+    .forEach((entry) => module.exports[entry[0]] = Stream[entry[0]])
   module.exports.Stream = Stream;
 } else {
   exports = module.exports = require('./lib/_stream_readable.js');


### PR DESCRIPTION
Follow-up to https://github.com/nodejs/readable-stream/pull/399. This PR fixes the below error, caused by recent versions of node adding a readonly `promises` property to the `Stream` constructor.

```
$ READABLE_STREAM=disable node
Welcome to Node.js v15.14.0.
Type ".help" for more information.
> var Readable = require('.')
Uncaught TypeError: Cannot set property promises of function Stream(opts) {
  EE.call(this, opts);
} which has only a getter
    at Function.assign (<anonymous>)
    at Object.<anonymous> (/home/ptaylor/dev/readable-stream/readable.js:4:10)
    at Module._compile (node:internal/modules/cjs/loader:1092:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
    at Module.load (node:internal/modules/cjs/loader:972:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Module.require (node:internal/modules/cjs/loader:996:19)
    at require (node:internal/modules/cjs/helpers:92:18)
> 
```
