### PR TITLE
Fix circular dependency

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -57,8 +57,8 @@ require('inherits')(Duplex, Readable);
 
 function Duplex(options) {
   if (!(this instanceof Duplex)) return new Duplex(options);
-  Readable.call(this, options);
-  Writable.call(this, options);
+  Readable.call(this, options, true);
+  Writable.call(this, options, true);
   this.allowHalfOpen = true;
 
   if (options) {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -21,10 +21,6 @@
 'use strict';
 
 module.exports = Readable;
-/*<replacement>*/
-
-var Duplex;
-/*</replacement>*/
 
 Readable.ReadableState = ReadableState;
 /*<replacement>*/
@@ -104,15 +100,11 @@ function prependListener(emitter, event, fn) {
 }
 
 function ReadableState(options, stream, isDuplex) {
-  Duplex = Duplex || require('./_stream_duplex');
   options = options || {}; // Duplex streams are both readable and writable, but share
   // the same options object.
   // However, some cases require setting options to different
   // values for the readable and the writable sides of the duplex stream.
   // These options can be provided separately as readableXXX and writableXXX.
-
-  if (typeof isDuplex !== 'boolean') isDuplex = stream instanceof Duplex; // object stream flag. Used to make read(n) ignore n and to
-  // make all the buffer merging and length checks go away
 
   this.objectMode = !!options.objectMode;
   if (isDuplex) this.objectMode = this.objectMode || !!options.readableObjectMode; // the point at which it stops calling _read() to fill the buffer
@@ -166,12 +158,13 @@ function ReadableState(options, stream, isDuplex) {
   }
 }
 
-function Readable(options) {
-  Duplex = Duplex || require('./_stream_duplex');
+function Readable(options, isDuplex) {
   if (!(this instanceof Readable)) return new Readable(options); // Checking for a Stream.Duplex instance is faster here instead of inside
   // the ReadableState constructor, at least with V8 6.5
 
-  var isDuplex = this instanceof Duplex;
+  if (typeof isDuplex !== 'boolean') isDuplex = false; // object stream flag. Used to make read(n) ignore n and to
+  // make all the buffer merging and length checks go away
+
   this._readableState = new ReadableState(options, this, isDuplex); // legacy
 
   this.readable = true;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -47,12 +47,6 @@ function CorkedRequest(state) {
 }
 /* </replacement> */
 
-/*<replacement>*/
-
-
-var Duplex;
-/*</replacement>*/
-
 Writable.WritableState = WritableState;
 /*<replacement>*/
 
@@ -101,15 +95,11 @@ require('inherits')(Writable, Stream);
 function nop() {}
 
 function WritableState(options, stream, isDuplex) {
-  Duplex = Duplex || require('./_stream_duplex');
   options = options || {}; // Duplex streams are both readable and writable, but share
   // the same options object.
   // However, some cases require setting options to different
   // values for the readable and the writable sides of the duplex stream,
   // e.g. options.readableObjectMode vs. options.writableObjectMode, etc.
-
-  if (typeof isDuplex !== 'boolean') isDuplex = stream instanceof Duplex; // object stream flag to indicate whether or not this stream
-  // contains buffers or objects.
 
   this.objectMode = !!options.objectMode;
   if (isDuplex) this.objectMode = this.objectMode || !!options.writableObjectMode; // the point at which write() starts returning false
@@ -226,8 +216,8 @@ if (typeof Symbol === 'function' && Symbol.hasInstance && typeof Function.protot
   };
 }
 
-function Writable(options) {
-  Duplex = Duplex || require('./_stream_duplex'); // Writable ctor is applied to Duplexes, too.
+function Writable(options, isDuplex) {
+  // Writable ctor is applied to Duplexes, too.
   // `realHasInstance` is necessary because using plain `instanceof`
   // would return false, as no `_writableState` property is attached.
   // Trying to use the custom `instanceof` for Writable here will also break the
@@ -236,7 +226,9 @@ function Writable(options) {
   // Checking for a Stream.Duplex instance is faster here instead of inside
   // the WritableState constructor, at least with V8 6.5
 
-  var isDuplex = this instanceof Duplex;
+  if (typeof isDuplex !== 'boolean') isDuplex = false; // object stream flag to indicate whether or not this stream
+  // contains buffers or objects.
+
   if (!isDuplex && !realHasInstance.call(Writable, this)) return new Writable(options);
   this._writableState = new WritableState(options, this, isDuplex); // legacy.
 


### PR DESCRIPTION
## Description

This PR fixes a circular dependency that has been affecting the rollup ecosystem for a long time. The fix is simple, as the circularity comes from a single type test that can be simply replaced with a boolean. (And the boolean already exists, it's just exposed to the Duplex child class now).

The root cause is due to rollup's handling of hoisting. Duplex inherits from Readable and Writable, but Readable and Writable check for Duplex-ity, ergo circular. As a result, when Duplex inherits from Readable/Writable, these two classes are hoisted but not yet defined.

The fix is simple: Replace the Duplex-ity test with a boolean, set by Duplex when it constructs its base classes.

This boolean actually already exists locally in both Readable and Writable, so it makes sense to use it to bust the circular dependency.

## Related PRs

Closes https://github.com/nodejs/readable-stream/issues/348
Closes https://github.com/calvinmetcalf/rollup-plugin-node-builtins/issues/31