### PR TITLE
fix: remove reference to global (browser support)

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -45,7 +45,7 @@ var Stream = require('./internal/streams/stream');
 
 var Buffer = require('buffer').Buffer;
 
-var OurUint8Array = global.Uint8Array || function () {};
+var OurUint8Array = Uint8Array || function () {};
 
 function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -69,7 +69,7 @@ var Stream = require('./internal/streams/stream');
 
 var Buffer = require('buffer').Buffer;
 
-var OurUint8Array = global.Uint8Array || function () {};
+var OurUint8Array = Uint8Array || function () {};
 
 function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);


### PR DESCRIPTION
## Description
This simple PR is about making `readable-stream` compatible with browsers without needing a `global` polyfill.

Fixes #426 

## Discussion
Since global objects are available everywhere, I believe that `global.Uint8Array` can be safely replaced by `Uint8Array`.
This fixes some issues with browser support, particularly when using this library in a Web worker, or when shimming `global` is not possible.