### PR TITLE
Evade override mistake

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -86,12 +86,22 @@ function E(code, message, Base) {
     }
   }
 
-  NodeError.prototype.name = Base.name
+  Object.defineProperties(NodeError.prototype, {
+    name: {
+      value: Base.name,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    },
+    toString: {
+      value() { return `${this.name} [${code}]: ${this.message}`; },
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    }    
+  });
   NodeError.prototype.code = code
   NodeError.prototype[kIsNodeError] = true
-  NodeError.prototype.toString = function () {
-    return `${this.name} [${code}]: ${this.message}`
-  }
 
   codes[code] = NodeError
 }


### PR DESCRIPTION
See https://github.com/Agoric/agoric-sdk/blob/master/patches/bl%2B%2Breadable-stream%2B3.6.0.patch

The original code used assignment to override the `name` and `toString` properties inherited from `Error.prototype`. However, if `Error.prototype` is frozen, as it is under Hardened JS (aka SES) or under the Node frozen intrinsics flag, then this assignment fails due to the JavaScript "override mistake".

`enumerable: true` would accurately preserve the behavior of the original assignment, but I'm guessing that was not intentional. For an actual error subclass, this property would not be enumerable, so my PR currently proposes that. But either would work, so let me know if you'd like me to change it.