### PR TITLE
Lazily require abort-controller

### DIFF
--- a/build/replacements.mjs
+++ b/build/replacements.mjs
@@ -14,7 +14,6 @@ const internalStreamsAbortControllerPolyfill = [
   `
   'use strict'
 
-  const abortControllerModule = require('abort-controller');
   `
 ]
 
@@ -30,7 +29,7 @@ const internalStreamsInspectCustom = ['inspect.custom', "Symbol.for('nodejs.util
 
 const internalStreamsNoRequireAbortController = [
   'const \\{ AbortController \\} = .+',
-  'const AbortController = globalThis.AbortController || abortControllerModule.AbortController;'
+  'const AbortController = globalThis.AbortController || require(\'abort-controller\').AbortController;'
 ]
 
 const internalStreamsRequireInternal = ["require\\('internal/([^']+)'\\)", "require('../$1')"]

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const abortControllerModule = require('abort-controller')
-
 const bufferModule = require('buffer')
 
 const {
@@ -40,7 +38,7 @@ const isBlob =
     : function isBlob(b) {
         return false
       }
-const AbortController = globalThis.AbortController || abortControllerModule.AbortController
+const AbortController = globalThis.AbortController || require('abort-controller').AbortController
 
 const { FunctionPrototypeCall } = require('../../ours/primordials') // This is needed for pre node 17.
 

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -38,6 +38,7 @@ const isBlob =
     : function isBlob(b) {
         return false
       }
+
 const AbortController = globalThis.AbortController || require('abort-controller').AbortController
 
 const { FunctionPrototypeCall } = require('../../ours/primordials') // This is needed for pre node 17.

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const abortControllerModule = require('abort-controller')
-
-const AbortController = globalThis.AbortController || abortControllerModule.AbortController
+const AbortController = globalThis.AbortController || require('abort-controller').AbortController
 
 const {
   codes: { ERR_INVALID_ARG_TYPE, ERR_MISSING_ARGS, ERR_OUT_OF_RANGE },

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -2,8 +2,6 @@
 // permission from the author, Mathias Buus (@mafintosh).
 'use strict'
 
-const abortControllerModule = require('abort-controller')
-
 const { ArrayIsArray, Promise, SymbolAsyncIterator } = require('../../ours/primordials')
 
 const eos = require('./end-of-stream')
@@ -24,7 +22,7 @@ const { validateFunction, validateAbortSignal } = require('../validators')
 
 const { isIterable, isReadable, isReadableNodeStream, isNodeStream } = require('./utils')
 
-const AbortController = globalThis.AbortController || abortControllerModule.AbortController
+const AbortController = globalThis.AbortController || require('abort-controller').AbortController
 let PassThrough
 let Readable
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -23,6 +23,7 @@ const { validateFunction, validateAbortSignal } = require('../validators')
 const { isIterable, isReadable, isReadableNodeStream, isNodeStream } = require('./utils')
 
 const AbortController = globalThis.AbortController || require('abort-controller').AbortController
+
 let PassThrough
 let Readable
 

--- a/lib/ours/errors.js
+++ b/lib/ours/errors.js
@@ -82,14 +82,25 @@ function E(code, message, Base) {
     }
   }
 
-  NodeError.prototype.name = Base.name
+  Object.defineProperties(NodeError.prototype, {
+    name: {
+      value: Base.name,
+      writable: true,
+      enumerable: false,
+      configurable: true
+    },
+    toString: {
+      value() {
+        return `${this.name} [${code}]: ${this.message}`
+      },
+
+      writable: true,
+      enumerable: false,
+      configurable: true
+    }
+  })
   NodeError.prototype.code = code
   NodeError.prototype[kIsNodeError] = true
-
-  NodeError.prototype.toString = function () {
-    return `${this.name} [${code}]: ${this.message}`
-  }
-
   codes[code] = NodeError
 }
 

--- a/test/browser/test-stream3-pause-then-read.js
+++ b/test/browser/test-stream3-pause-then-read.js
@@ -47,7 +47,6 @@ module.exports = function (t) {
   function readn(n, then) {
     // console.error('read %d', n);
     expectEndingData -= n
-
     ;(function read() {
       const c = r.read(n)
 

--- a/test/common/fixtures.mjs
+++ b/test/common/fixtures.mjs
@@ -1,17 +1,5 @@
-import fixtures from './fixtures.js';
+import fixtures from './fixtures.js'
 
-const {
-  fixturesDir,
-  path,
-  fileURL,
-  readSync,
-  readKey,
-} = fixtures;
+const { fixturesDir, path, fileURL, readSync, readKey } = fixtures
 
-export {
-  fixturesDir,
-  path,
-  fileURL,
-  readSync,
-  readKey,
-};
+export { fixturesDir, path, fileURL, readSync, readKey }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -124,7 +124,7 @@ const isOSX = process.platform === 'darwin'
 
 const isPi = (() => {
   try {
-    var _$exec
+    var _exec
 
     // Normal Raspberry Pi detection is to find the `Raspberry Pi` string in
     // the contents of `/sys/firmware/devicetree/base/model` but that doesn't
@@ -133,7 +133,7 @@ const isPi = (() => {
       encoding: 'utf8'
     })
     return (
-      ((_$exec = /^Hardware\s*:\s*(.*)$/im.exec(cpuinfo)) === null || _$exec === undefined ? undefined : _$exec[1]) ===
+      ((_exec = /^Hardware\s*:\s*(.*)$/im.exec(cpuinfo)) === null || _exec === undefined ? undefined : _exec[1]) ===
       'BCM2835'
     )
   } catch {

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -1,7 +1,7 @@
-import { createRequire } from 'module';
+import { createRequire } from 'module'
 
-const require = createRequire(import.meta.url);
-const common = require('./index.js');
+const require = createRequire(import.meta.url)
+const common = require('./index.js')
 
 const {
   isMainThread,
@@ -47,7 +47,7 @@ const {
   getBufferSources,
   getTTYfd,
   runWithInvalidFD
-} = common;
+} = common
 
 export {
   isMainThread,
@@ -94,4 +94,4 @@ export {
   getTTYfd,
   runWithInvalidFD,
   createRequire
-};
+}

--- a/test/parallel/test-stream-asIndexedPairs.mjs
+++ b/test/parallel/test-stream-asIndexedPairs.mjs
@@ -1,64 +1,82 @@
-import '../common/index.mjs';
-import { Readable }from '../../lib/ours/index.js';
-import { deepStrictEqual, rejects, throws } from 'assert';
-import tap from 'tap';
+import '../common/index.mjs'
+import { Readable } from '../../lib/ours/index.js'
+import { deepStrictEqual, rejects, throws } from 'assert'
+import tap from 'tap'
 
 {
   // asIndexedPairs with a synchronous stream
-  const pairs = await Readable.from([1, 2, 3]).asIndexedPairs().toArray();
-  deepStrictEqual(pairs, [[0, 1], [1, 2], [2, 3]]);
-  const empty = await Readable.from([]).asIndexedPairs().toArray();
-  deepStrictEqual(empty, []);
+  const pairs = await Readable.from([1, 2, 3]).asIndexedPairs().toArray()
+  deepStrictEqual(pairs, [
+    [0, 1],
+    [1, 2],
+    [2, 3]
+  ])
+  const empty = await Readable.from([]).asIndexedPairs().toArray()
+  deepStrictEqual(empty, [])
 }
 
 {
   // asIndexedPairs works an asynchronous streams
-  const asyncFrom = (...args) => Readable.from(...args).map(async (x) => x);
-  const pairs = await asyncFrom([1, 2, 3]).asIndexedPairs().toArray();
-  deepStrictEqual(pairs, [[0, 1], [1, 2], [2, 3]]);
-  const empty = await asyncFrom([]).asIndexedPairs().toArray();
-  deepStrictEqual(empty, []);
+  const asyncFrom = (...args) => Readable.from(...args).map(async (x) => x)
+  const pairs = await asyncFrom([1, 2, 3]).asIndexedPairs().toArray()
+  deepStrictEqual(pairs, [
+    [0, 1],
+    [1, 2],
+    [2, 3]
+  ])
+  const empty = await asyncFrom([]).asIndexedPairs().toArray()
+  deepStrictEqual(empty, [])
 }
 
 {
   // Does not enumerate an infinite stream
-  const infinite = () => Readable.from(async function* () {
-    while (true) yield 1;
-  }());
-  const pairs = await infinite().asIndexedPairs().take(3).toArray();
-  deepStrictEqual(pairs, [[0, 1], [1, 1], [2, 1]]);
-  const empty = await infinite().asIndexedPairs().take(0).toArray();
-  deepStrictEqual(empty, []);
+  const infinite = () =>
+    Readable.from(
+      (async function* () {
+        while (true) yield 1
+      })()
+    )
+  const pairs = await infinite().asIndexedPairs().take(3).toArray()
+  deepStrictEqual(pairs, [
+    [0, 1],
+    [1, 1],
+    [2, 1]
+  ])
+  const empty = await infinite().asIndexedPairs().take(0).toArray()
+  deepStrictEqual(empty, [])
 }
 
 {
   // AbortSignal
-  await rejects(async () => {
-    const ac = new AbortController();
-    const { signal } = ac;
-    const p = Readable.from([1, 2, 3]).asIndexedPairs({ signal }).toArray();
-    ac.abort();
-    await p;
-  }, { name: 'AbortError' });
+  await rejects(
+    async () => {
+      const ac = new AbortController()
+      const { signal } = ac
+      const p = Readable.from([1, 2, 3]).asIndexedPairs({ signal }).toArray()
+      ac.abort()
+      await p
+    },
+    { name: 'AbortError' }
+  )
 
   await rejects(async () => {
-    const signal = AbortSignal.abort();
-    await Readable.from([1, 2, 3]).asIndexedPairs({ signal }).toArray();
-  }, /AbortError/);
+    const signal = AbortSignal.abort()
+    await Readable.from([1, 2, 3]).asIndexedPairs({ signal }).toArray()
+  }, /AbortError/)
 }
 
 {
   // Error cases
-  throws(() => Readable.from([1]).asIndexedPairs(1), /ERR_INVALID_ARG_TYPE/);
-  throws(() => Readable.from([1]).asIndexedPairs({ signal: true }), /ERR_INVALID_ARG_TYPE/);
+  throws(() => Readable.from([1]).asIndexedPairs(1), /ERR_INVALID_ARG_TYPE/)
+  throws(() => Readable.from([1]).asIndexedPairs({ signal: true }), /ERR_INVALID_ARG_TYPE/)
 }
 
-  /* replacement start */
-  process.on('beforeExit', (code) => {
-    if(code === 0) {
-      tap.pass('test succeeded');
-    } else {
-      tap.fail(`test failed - exited code ${code}`);
-    }
-  });
-  /* replacement end */
+/* replacement start */
+process.on('beforeExit', (code) => {
+  if (code === 0) {
+    tap.pass('test succeeded')
+  } else {
+    tap.fail(`test failed - exited code ${code}`)
+  }
+})
+/* replacement end */

--- a/test/parallel/test-stream-drop-take.js
+++ b/test/parallel/test-stream-drop-take.js
@@ -55,7 +55,6 @@ const naturals = () =>
     deepStrictEqual(await from([1, 2]).drop(0).toArray(), [1, 2])
     deepStrictEqual(await from([1, 2]).take(0).toArray(), [])
   })().then(common.mustCall()) // Asynchronous streams
-
   ;(async () => {
     deepStrictEqual(await fromAsync([1, 2, 3]).drop(2).toArray(), [3])
     deepStrictEqual(await fromAsync([1, 2, 3]).take(1).toArray(), [1])
@@ -66,7 +65,6 @@ const naturals = () =>
     deepStrictEqual(await fromAsync([1, 2]).take(0).toArray(), [])
   })().then(common.mustCall()) // Infinite streams
   // Asynchronous streams
-
   ;(async () => {
     deepStrictEqual(await naturals().take(1).toArray(), [1])
     deepStrictEqual(await naturals().drop(1).take(1).toArray(), [2])

--- a/test/parallel/test-stream-flatMap.js
+++ b/test/parallel/test-stream-flatMap.js
@@ -91,7 +91,6 @@ function oneTo5() {
       .toArray()
     assert.deepStrictEqual(result, [1, 1, 2, 2, 3, 3, 4, 4, 5, 5])
   })().then(common.mustCall()) // flatMap works on an objectMode stream where mappign returns a stream
-
   ;(async () => {
     const result = await oneTo5()
       .flatMap(() => {

--- a/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
+++ b/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
@@ -1,7 +1,7 @@
-import { mustCall } from '../common/index.mjs';
-import { Readable }from '../../lib/ours/index.js';
-import assert from 'assert';
-import tap from 'tap';
+import { mustCall } from '../common/index.mjs'
+import { Readable } from '../../lib/ours/index.js'
+import assert from 'assert'
+import tap from 'tap'
 
 // These tests are manually ported from the draft PR for the test262 test suite
 // Authored by Rick Waldron in https://github.com/tc39/test262/pull/2818/files
@@ -46,134 +46,131 @@ import tap from 'tap';
 // * Ecma International Standards hereafter means Ecma International Standards
 // as well as Ecma Technical Reports
 
-
 // Note all the tests that check AsyncIterator's prototype itself and things
 // that happen before stream conversion were not ported.
 {
   // asIndexedPairs/is-function
-  assert.strictEqual(typeof Readable.prototype.asIndexedPairs, 'function');
+  assert.strictEqual(typeof Readable.prototype.asIndexedPairs, 'function')
   // asIndexedPairs/indexed-pairs.js
-  const iterator = Readable.from([0, 1]);
-  const indexedPairs = iterator.asIndexedPairs();
+  const iterator = Readable.from([0, 1])
+  const indexedPairs = iterator.asIndexedPairs()
 
   for await (const [i, v] of indexedPairs) {
-    assert.strictEqual(i, v);
+    assert.strictEqual(i, v)
   }
   // asIndexedPairs/length.js
-  assert.strictEqual(Readable.prototype.asIndexedPairs.length, 0);
+  assert.strictEqual(Readable.prototype.asIndexedPairs.length, 0)
   // asIndexedPairs/name.js
-  assert.strictEqual(Readable.prototype.asIndexedPairs.name, 'asIndexedPairs');
-  const descriptor = Object.getOwnPropertyDescriptor(
-    Readable.prototype,
-    'asIndexedPairs'
-  );
-  assert.strictEqual(descriptor.enumerable, false);
-  assert.strictEqual(descriptor.configurable, true);
-  assert.strictEqual(descriptor.writable, true);
+  assert.strictEqual(Readable.prototype.asIndexedPairs.name, 'asIndexedPairs')
+  const descriptor = Object.getOwnPropertyDescriptor(Readable.prototype, 'asIndexedPairs')
+  assert.strictEqual(descriptor.enumerable, false)
+  assert.strictEqual(descriptor.configurable, true)
+  assert.strictEqual(descriptor.writable, true)
 }
 {
   // drop/length
-  assert.strictEqual(Readable.prototype.drop.length, 1);
-  const descriptor = Object.getOwnPropertyDescriptor(
-    Readable.prototype,
-    'drop'
-  );
-  assert.strictEqual(descriptor.enumerable, false);
-  assert.strictEqual(descriptor.configurable, true);
-  assert.strictEqual(descriptor.writable, true);
+  assert.strictEqual(Readable.prototype.drop.length, 1)
+  const descriptor = Object.getOwnPropertyDescriptor(Readable.prototype, 'drop')
+  assert.strictEqual(descriptor.enumerable, false)
+  assert.strictEqual(descriptor.configurable, true)
+  assert.strictEqual(descriptor.writable, true)
   // drop/limit-equals-total
-  const iterator = Readable.from([1, 2]).drop(2);
-  const result = await iterator[Symbol.asyncIterator]().next();
-  assert.deepStrictEqual(result, { done: true, value: undefined });
+  const iterator = Readable.from([1, 2]).drop(2)
+  const result = await iterator[Symbol.asyncIterator]().next()
+  assert.deepStrictEqual(result, { done: true, value: undefined })
   // drop/limit-greater-than-total.js
-  const iterator2 = Readable.from([1, 2]).drop(3);
-  const result2 = await iterator2[Symbol.asyncIterator]().next();
-  assert.deepStrictEqual(result2, { done: true, value: undefined });
+  const iterator2 = Readable.from([1, 2]).drop(3)
+  const result2 = await iterator2[Symbol.asyncIterator]().next()
+  assert.deepStrictEqual(result2, { done: true, value: undefined })
   // drop/limit-less-than-total.js
-  const iterator3 = Readable.from([1, 2]).drop(1);
-  const result3 = await iterator3[Symbol.asyncIterator]().next();
-  assert.deepStrictEqual(result3, { done: false, value: 2 });
+  const iterator3 = Readable.from([1, 2]).drop(1)
+  const result3 = await iterator3[Symbol.asyncIterator]().next()
+  assert.deepStrictEqual(result3, { done: false, value: 2 })
   // drop/limit-rangeerror
-  assert.throws(() => Readable.from([1]).drop(-1), RangeError);
+  assert.throws(() => Readable.from([1]).drop(-1), RangeError)
   assert.throws(() => {
     Readable.from([1]).drop({
       valueOf() {
-        throw new Error('boom');
+        throw new Error('boom')
       }
-    });
-  }, /boom/);
+    })
+  }, /boom/)
   // drop/limit-tointeger
-  const two = await Readable.from([1, 2]).drop({ valueOf: () => 1 }).toArray();
-  assert.deepStrictEqual(two, [2]);
+  const two = await Readable.from([1, 2])
+    .drop({ valueOf: () => 1 })
+    .toArray()
+  assert.deepStrictEqual(two, [2])
   // drop/name
-  assert.strictEqual(Readable.prototype.drop.name, 'drop');
+  assert.strictEqual(Readable.prototype.drop.name, 'drop')
   // drop/non-constructible
-  assert.throws(() => new Readable.prototype.drop(1), TypeError);
+  assert.throws(() => new Readable.prototype.drop(1), TypeError)
   // drop/proto
-  const proto = Object.getPrototypeOf(Readable.prototype.drop);
-  assert.strictEqual(proto, Function.prototype);
+  const proto = Object.getPrototypeOf(Readable.prototype.drop)
+  assert.strictEqual(proto, Function.prototype)
 }
 {
   // every/abrupt-iterator-close
-  const stream = Readable.from([1, 2, 3]);
-  const e = new Error();
-  await assert.rejects(stream.every(mustCall(() => {
-    throw e;
-  }, 1)), e);
+  const stream = Readable.from([1, 2, 3])
+  const e = new Error()
+  await assert.rejects(
+    stream.every(
+      mustCall(() => {
+        throw e
+      }, 1)
+    ),
+    e
+  )
 }
 {
   // every/callable-fn
-  await assert.rejects(Readable.from([1, 2]).every({}), TypeError);
+  await assert.rejects(Readable.from([1, 2]).every({}), TypeError)
 }
 {
   // every/callable
-  Readable.prototype.every.call(Readable.from([]), () => {});
+  Readable.prototype.every.call(Readable.from([]), () => {})
   // eslint-disable-next-line array-callback-return
-  Readable.from([]).every(() => {});
+  Readable.from([]).every(() => {})
   assert.throws(() => {
-    const r = Readable.from([]);
-    new r.every(() => {});
-  }, TypeError);
+    const r = Readable.from([])
+    new r.every(() => {})
+  }, TypeError)
 }
 
 {
   // every/false
-  const iterator = Readable.from([1, 2, 3]);
-  const result = await iterator.every((v) => v === 1);
-  assert.strictEqual(result, false);
+  const iterator = Readable.from([1, 2, 3])
+  const result = await iterator.every((v) => v === 1)
+  assert.strictEqual(result, false)
 }
 {
   // every/every
-  const iterator = Readable.from([1, 2, 3]);
-  const result = await iterator.every((v) => true);
-  assert.strictEqual(result, true);
+  const iterator = Readable.from([1, 2, 3])
+  const result = await iterator.every((v) => true)
+  assert.strictEqual(result, true)
 }
 
 {
   // every/is-function
-  assert.strictEqual(typeof Readable.prototype.every, 'function');
+  assert.strictEqual(typeof Readable.prototype.every, 'function')
 }
 {
   // every/length
-  assert.strictEqual(Readable.prototype.every.length, 1);
+  assert.strictEqual(Readable.prototype.every.length, 1)
   // every/name
-  assert.strictEqual(Readable.prototype.every.name, 'every');
+  assert.strictEqual(Readable.prototype.every.name, 'every')
   // every/propdesc
-  const descriptor = Object.getOwnPropertyDescriptor(
-    Readable.prototype,
-    'every'
-  );
-  assert.strictEqual(descriptor.enumerable, false);
-  assert.strictEqual(descriptor.configurable, true);
-  assert.strictEqual(descriptor.writable, true);
+  const descriptor = Object.getOwnPropertyDescriptor(Readable.prototype, 'every')
+  assert.strictEqual(descriptor.enumerable, false)
+  assert.strictEqual(descriptor.configurable, true)
+  assert.strictEqual(descriptor.writable, true)
 }
 
-  /* replacement start */
-  process.on('beforeExit', (code) => {
-    if(code === 0) {
-      tap.pass('test succeeded');
-    } else {
-      tap.fail(`test failed - exited code ${code}`);
-    }
-  });
-  /* replacement end */
+/* replacement start */
+process.on('beforeExit', (code) => {
+  if (code === 0) {
+    tap.pass('test succeeded')
+  } else {
+    tap.fail(`test failed - exited code ${code}`)
+  }
+})
+/* replacement end */

--- a/test/parallel/test-stream-some-find-every.mjs
+++ b/test/parallel/test-stream-some-find-every.mjs
@@ -1,183 +1,215 @@
-import * as common from '../common/index.mjs';
-import { setTimeout } from 'timers/promises';
-import { Readable }from '../../lib/ours/index.js';
-import assert from 'assert';
-import tap from 'tap';
-
+import * as common from '../common/index.mjs'
+import { setTimeout } from 'timers/promises'
+import { Readable } from '../../lib/ours/index.js'
+import assert from 'assert'
+import tap from 'tap'
 
 function oneTo5() {
-  return Readable.from([1, 2, 3, 4, 5]);
+  return Readable.from([1, 2, 3, 4, 5])
 }
 
 function oneTo5Async() {
   return oneTo5().map(async (x) => {
-    await Promise.resolve();
-    return x;
-  });
+    await Promise.resolve()
+    return x
+  })
 }
 {
   // Some, find, and every work with a synchronous stream and predicate
-  assert.strictEqual(await oneTo5().some((x) => x > 3), true);
-  assert.strictEqual(await oneTo5().every((x) => x > 3), false);
-  assert.strictEqual(await oneTo5().find((x) => x > 3), 4);
-  assert.strictEqual(await oneTo5().some((x) => x > 6), false);
-  assert.strictEqual(await oneTo5().every((x) => x < 6), true);
-  assert.strictEqual(await oneTo5().find((x) => x > 6), undefined);
-  assert.strictEqual(await Readable.from([]).some(() => true), false);
-  assert.strictEqual(await Readable.from([]).every(() => true), true);
-  assert.strictEqual(await Readable.from([]).find(() => true), undefined);
+  assert.strictEqual(await oneTo5().some((x) => x > 3), true)
+  assert.strictEqual(await oneTo5().every((x) => x > 3), false)
+  assert.strictEqual(await oneTo5().find((x) => x > 3), 4)
+  assert.strictEqual(await oneTo5().some((x) => x > 6), false)
+  assert.strictEqual(await oneTo5().every((x) => x < 6), true)
+  assert.strictEqual(await oneTo5().find((x) => x > 6), undefined)
+  assert.strictEqual(await Readable.from([]).some(() => true), false)
+  assert.strictEqual(await Readable.from([]).every(() => true), true)
+  assert.strictEqual(await Readable.from([]).find(() => true), undefined)
 }
 
 {
   // Some, find, and every work with an asynchronous stream and synchronous predicate
-  assert.strictEqual(await oneTo5Async().some((x) => x > 3), true);
-  assert.strictEqual(await oneTo5Async().every((x) => x > 3), false);
-  assert.strictEqual(await oneTo5Async().find((x) => x > 3), 4);
-  assert.strictEqual(await oneTo5Async().some((x) => x > 6), false);
-  assert.strictEqual(await oneTo5Async().every((x) => x < 6), true);
-  assert.strictEqual(await oneTo5Async().find((x) => x > 6), undefined);
+  assert.strictEqual(await oneTo5Async().some((x) => x > 3), true)
+  assert.strictEqual(await oneTo5Async().every((x) => x > 3), false)
+  assert.strictEqual(await oneTo5Async().find((x) => x > 3), 4)
+  assert.strictEqual(await oneTo5Async().some((x) => x > 6), false)
+  assert.strictEqual(await oneTo5Async().every((x) => x < 6), true)
+  assert.strictEqual(await oneTo5Async().find((x) => x > 6), undefined)
 }
 
 {
   // Some, find, and every work on synchronous streams with an asynchronous predicate
-  assert.strictEqual(await oneTo5().some(async (x) => x > 3), true);
-  assert.strictEqual(await oneTo5().every(async (x) => x > 3), false);
-  assert.strictEqual(await oneTo5().find(async (x) => x > 3), 4);
-  assert.strictEqual(await oneTo5().some(async (x) => x > 6), false);
-  assert.strictEqual(await oneTo5().every(async (x) => x < 6), true);
-  assert.strictEqual(await oneTo5().find(async (x) => x > 6), undefined);
+  assert.strictEqual(await oneTo5().some(async (x) => x > 3), true)
+  assert.strictEqual(await oneTo5().every(async (x) => x > 3), false)
+  assert.strictEqual(await oneTo5().find(async (x) => x > 3), 4)
+  assert.strictEqual(await oneTo5().some(async (x) => x > 6), false)
+  assert.strictEqual(await oneTo5().every(async (x) => x < 6), true)
+  assert.strictEqual(await oneTo5().find(async (x) => x > 6), undefined)
 }
 
 {
   // Some, find, and every work on asynchronous streams with an asynchronous predicate
-  assert.strictEqual(await oneTo5Async().some(async (x) => x > 3), true);
-  assert.strictEqual(await oneTo5Async().every(async (x) => x > 3), false);
-  assert.strictEqual(await oneTo5Async().find(async (x) => x > 3), 4);
-  assert.strictEqual(await oneTo5Async().some(async (x) => x > 6), false);
-  assert.strictEqual(await oneTo5Async().every(async (x) => x < 6), true);
-  assert.strictEqual(await oneTo5Async().find(async (x) => x > 6), undefined);
+  assert.strictEqual(await oneTo5Async().some(async (x) => x > 3), true)
+  assert.strictEqual(await oneTo5Async().every(async (x) => x > 3), false)
+  assert.strictEqual(await oneTo5Async().find(async (x) => x > 3), 4)
+  assert.strictEqual(await oneTo5Async().some(async (x) => x > 6), false)
+  assert.strictEqual(await oneTo5Async().every(async (x) => x < 6), true)
+  assert.strictEqual(await oneTo5Async().find(async (x) => x > 6), undefined)
 }
 
 {
   async function checkDestroyed(stream) {
-    await setTimeout();
-    assert.strictEqual(stream.destroyed, true);
+    await setTimeout()
+    assert.strictEqual(stream.destroyed, true)
   }
 
   {
     // Some, find, and every short circuit
-    const someStream = oneTo5();
-    await someStream.some(common.mustCall((x) => x > 2, 3));
-    await checkDestroyed(someStream);
+    const someStream = oneTo5()
+    await someStream.some(common.mustCall((x) => x > 2, 3))
+    await checkDestroyed(someStream)
 
-    const everyStream = oneTo5();
-    await everyStream.every(common.mustCall((x) => x < 3, 3));
-    await checkDestroyed(everyStream);
+    const everyStream = oneTo5()
+    await everyStream.every(common.mustCall((x) => x < 3, 3))
+    await checkDestroyed(everyStream)
 
-    const findStream = oneTo5();
-    await findStream.find(common.mustCall((x) => x > 1, 2));
-    await checkDestroyed(findStream);
+    const findStream = oneTo5()
+    await findStream.find(common.mustCall((x) => x > 1, 2))
+    await checkDestroyed(findStream)
 
     // When short circuit isn't possible the whole stream is iterated
-    await oneTo5().some(common.mustCall(() => false, 5));
-    await oneTo5().every(common.mustCall(() => true, 5));
-    await oneTo5().find(common.mustCall(() => false, 5));
+    await oneTo5().some(common.mustCall(() => false, 5))
+    await oneTo5().every(common.mustCall(() => true, 5))
+    await oneTo5().find(common.mustCall(() => false, 5))
   }
 
   {
     // Some, find, and every short circuit async stream/predicate
-    const someStream = oneTo5Async();
-    await someStream.some(common.mustCall(async (x) => x > 2, 3));
-    await checkDestroyed(someStream);
+    const someStream = oneTo5Async()
+    await someStream.some(common.mustCall(async (x) => x > 2, 3))
+    await checkDestroyed(someStream)
 
-    const everyStream = oneTo5Async();
-    await everyStream.every(common.mustCall(async (x) => x < 3, 3));
-    await checkDestroyed(everyStream);
+    const everyStream = oneTo5Async()
+    await everyStream.every(common.mustCall(async (x) => x < 3, 3))
+    await checkDestroyed(everyStream)
 
-    const findStream = oneTo5Async();
-    await findStream.find(common.mustCall(async (x) => x > 1, 2));
-    await checkDestroyed(findStream);
+    const findStream = oneTo5Async()
+    await findStream.find(common.mustCall(async (x) => x > 1, 2))
+    await checkDestroyed(findStream)
 
     // When short circuit isn't possible the whole stream is iterated
-    await oneTo5Async().some(common.mustCall(async () => false, 5));
-    await oneTo5Async().every(common.mustCall(async () => true, 5));
-    await oneTo5Async().find(common.mustCall(async () => false, 5));
+    await oneTo5Async().some(common.mustCall(async () => false, 5))
+    await oneTo5Async().every(common.mustCall(async () => true, 5))
+    await oneTo5Async().find(common.mustCall(async () => false, 5))
   }
 }
 
 {
   // Concurrency doesn't affect which value is found.
-  const found = await Readable.from([1, 2]).find(async (val) => {
-    if (val === 1) {
-      await setTimeout(100);
-    }
-    return true;
-  }, { concurrency: 2 });
-  assert.strictEqual(found, 1);
+  const found = await Readable.from([1, 2]).find(
+    async (val) => {
+      if (val === 1) {
+        await setTimeout(100)
+      }
+      return true
+    },
+    { concurrency: 2 }
+  )
+  assert.strictEqual(found, 1)
 }
 
 {
   // Support for AbortSignal
   for (const op of ['some', 'every', 'find']) {
     {
-      const ac = new AbortController();
-      assert.rejects(Readable.from([1, 2, 3])[op](
-        () => new Promise(() => { }),
-        { signal: ac.signal }
-      ), {
-        name: 'AbortError',
-      }, `${op} should abort correctly with sync abort`).then(common.mustCall());
-      ac.abort();
+      const ac = new AbortController()
+      assert
+        .rejects(
+          Readable.from([1, 2, 3])[op](() => new Promise(() => {}), { signal: ac.signal }),
+          {
+            name: 'AbortError'
+          },
+          `${op} should abort correctly with sync abort`
+        )
+        .then(common.mustCall())
+      ac.abort()
     }
     {
       // Support for pre-aborted AbortSignal
-      assert.rejects(Readable.from([1, 2, 3])[op](
-        () => new Promise(() => { }),
-        { signal: AbortSignal.abort() }
-      ), {
-        name: 'AbortError',
-      }, `${op} should abort with pre-aborted abort controller`).then(common.mustCall());
+      assert
+        .rejects(
+          Readable.from([1, 2, 3])[op](() => new Promise(() => {}), { signal: AbortSignal.abort() }),
+          {
+            name: 'AbortError'
+          },
+          `${op} should abort with pre-aborted abort controller`
+        )
+        .then(common.mustCall())
     }
   }
 }
 {
   // Error cases
   for (const op of ['some', 'every', 'find']) {
-    assert.rejects(async () => {
-      await Readable.from([1])[op](1);
-    }, /ERR_INVALID_ARG_TYPE/, `${op} should throw for invalid function`).then(common.mustCall());
-    assert.rejects(async () => {
-      await Readable.from([1])[op]((x) => x, {
-        concurrency: 'Foo'
-      });
-    }, /ERR_OUT_OF_RANGE/, `${op} should throw for invalid concurrency`).then(common.mustCall());
-    assert.rejects(async () => {
-      await Readable.from([1])[op]((x) => x, 1);
-    }, /ERR_INVALID_ARG_TYPE/, `${op} should throw for invalid concurrency`).then(common.mustCall());
-    assert.rejects(async () => {
-      await Readable.from([1])[op]((x) => x, {
-        signal: true
-      });
-    }, /ERR_INVALID_ARG_TYPE/, `${op} should throw for invalid signal`).then(common.mustCall());
+    assert
+      .rejects(
+        async () => {
+          await Readable.from([1])[op](1)
+        },
+        /ERR_INVALID_ARG_TYPE/,
+        `${op} should throw for invalid function`
+      )
+      .then(common.mustCall())
+    assert
+      .rejects(
+        async () => {
+          await Readable.from([1])[op]((x) => x, {
+            concurrency: 'Foo'
+          })
+        },
+        /ERR_OUT_OF_RANGE/,
+        `${op} should throw for invalid concurrency`
+      )
+      .then(common.mustCall())
+    assert
+      .rejects(
+        async () => {
+          await Readable.from([1])[op]((x) => x, 1)
+        },
+        /ERR_INVALID_ARG_TYPE/,
+        `${op} should throw for invalid concurrency`
+      )
+      .then(common.mustCall())
+    assert
+      .rejects(
+        async () => {
+          await Readable.from([1])[op]((x) => x, {
+            signal: true
+          })
+        },
+        /ERR_INVALID_ARG_TYPE/,
+        `${op} should throw for invalid signal`
+      )
+      .then(common.mustCall())
   }
 }
 {
   for (const op of ['some', 'every', 'find']) {
-    const stream = oneTo5();
+    const stream = oneTo5()
     Object.defineProperty(stream, 'map', {
-      value: common.mustNotCall(() => {}),
-    });
+      value: common.mustNotCall(() => {})
+    })
     // Check that map isn't getting called.
-    stream[op](() => {});
+    stream[op](() => {})
   }
 }
 
-  /* replacement start */
-  process.on('beforeExit', (code) => {
-    if(code === 0) {
-      tap.pass('test succeeded');
-    } else {
-      tap.fail(`test failed - exited code ${code}`);
-    }
-  });
-  /* replacement end */
+/* replacement start */
+process.on('beforeExit', (code) => {
+  if (code === 0) {
+    tap.pass('test succeeded')
+  } else {
+    tap.fail(`test failed - exited code ${code}`)
+  }
+})
+/* replacement end */

--- a/test/parallel/test-stream-transform-split-highwatermark.js
+++ b/test/parallel/test-stream-transform-split-highwatermark.js
@@ -66,7 +66,6 @@ testTransform(0, 0, {
   readableHighWaterMark: 666,
   writableHighWaterMark: 777
 }) // Test undefined, null
-
 ;[undefined, null].forEach((v) => {
   testTransform(DEFAULT, DEFAULT, {
     readableHighWaterMark: v

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -57,7 +57,6 @@ class MyWritable extends stream.Writable {
   m.write('foo')
   m.end()
 })()
-
 ;(function changeDefaultEncodingToAscii() {
   const m = new MyWritable(
     function (isBuffer, type, enc) {
@@ -87,7 +86,6 @@ assert.throws(
     message: 'Unknown encoding: {}'
   }
 )
-
 ;(function checkVariableCaseEncoding() {
   const m = new MyWritable(
     function (isBuffer, type, enc) {

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -73,7 +73,6 @@ function read100() {
 function readn(n, then) {
   silentConsole.error(`read ${n}`)
   expectEndingData -= n
-
   ;(function read() {
     const c = r.read(n)
     silentConsole.error('c', c)


### PR DESCRIPTION
It throws when it has been bundled, then loaded in node.

How I found this:

- Updating dependencies in [cbor](https://github.com/hildjj/node-cbor/)
- In the `cbor-web` sub-package, I use webpack to pre-bundle `cbor` for easy use in the browser
- I then spot-check that webpack'd version in node to ensure that it works as expected
- This error: `TypeError: Cannot destructure property 'AbortController'`
- Tracked it back to [code](https://github.com/mysticatea/abort-controller/blob/a935d38e09eb95d6b633a8c42fcceec9969e7b05/browser.js#L5) in `abort-controller`, which *should* only get used in the browser, but because I'm running a bundle, I hit it in node
- Backtracked into readable-stream.  There's no reason to require `abort-controller` unless `globalThis.AbortController` doesn't exist
- Moving the require after the `globalThis.AbortController` check fixes my issue

This is probably an edge case that I hope nobody else runs into, but the fix for my problem shouldn't hurt anyone else.