### PR TITLE
ci: add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -2,6 +2,9 @@ name: Browsers
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Browsers

--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -2,6 +2,9 @@ name: Bundlers
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Bundlers

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,6 +2,9 @@ name: Node.js
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Node.js


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>