### PR TITLE
Remove requirement for bundler custom config

### DIFF
--- a/build/build.mjs
+++ b/build/build.mjs
@@ -15,6 +15,7 @@ import { headers } from './headers.mjs'
 import { replacements } from './replacements.mjs'
 
 const baseMatcher = /^(?:lib|test)/
+const strictMatcher = /^(['"']use strict.+)/
 
 function highlightFile(file, color) {
   return `\x1b[${color}m${file.replace(process.cwd() + '/', '')}\x1b[0m`
@@ -101,7 +102,11 @@ async function processFiles(contents) {
 
       for (const footerKey of matchingHeaders) {
         for (const header of headers[footerKey]) {
-          content = header + content
+          if (content.match(strictMatcher)) {
+            content = content.replace(strictMatcher, `$&;${header}`)
+          } else {
+            content = header + content
+          }
         }
       }
     }

--- a/build/headers.mjs
+++ b/build/headers.mjs
@@ -1,3 +1,19 @@
+const bufferRequire = `
+  /* replacement start */
+
+  const { Buffer } = require('buffer')
+
+  /* replacement end */
+`
+
+const processRequire = `
+  /* replacement start */
+
+  const process = require('process')
+
+  /* replacement end */
+`
+
 const testPolyfills = `
   /* replacement start */
   const AbortController = globalThis.AbortController || require('abort-controller').AbortController;
@@ -16,6 +32,16 @@ const testPolyfills = `
 `
 
 export const headers = {
+  'lib/stream.js':
+    [bufferRequire],
+  'lib/internal/streams/(destroy|duplexify|end-of-stream|from|pipeline|readable|writable).js':
+    [processRequire],
+  'test/browser/test-stream-(big-packet|pipe-cleanup-pause|pipeline|readable-event|transform-constructor-set-methods|transform-split-objectmode|unshift-empty-chunk|unshift-read-race|writable-change-default-encoding|writable-constructor-set-methods|writable-decoded-encoding|writev).js':
+    [bufferRequire],
+  'test/browser/test-stream2-(base64-single-char-read-end|compatibility|large-read-stall|pipe-error-handling|readable-empty-buffer-no-eof|readable-from-list|readable-legacy-drain|readable-non-empty-end|readable-wrap|set-encoding|transform|writable).js':
+    [bufferRequire],
+  'test/browser/test-stream3-pause-then-read.js':
+    [bufferRequire],
   'test/parallel/test-stream-(add-abort-signal|drop-take|duplex-destroy|flatMap|forEach|filter|finished|readable-destroy|reduce|toArray|writable-destroy).js':
     [testPolyfills]
 }

--- a/build/replacements.mjs
+++ b/build/replacements.mjs
@@ -34,8 +34,6 @@ const internalStreamsNoRequireAbortController = [
 
 const internalStreamsRequireInternal = ["require\\('internal/([^']+)'\\)", "require('../$1')"]
 
-const internalStreamsNoRequireBuffer = ["const \\{ Buffer \\} = require\\('buffer'\\);", '']
-
 const internalStreamsRequireErrors = ["require\\('internal/errors'\\)", "require('../../ours/errors')"]
 
 const internalStreamsRequireEventEmitter = ['const EE =', 'const { EventEmitter: EE } =']
@@ -233,7 +231,6 @@ export const replacements = {
     internalStreamsNoRequireAbortController
   ],
   'lib/internal/streams/.+': [
-    internalStreamsNoRequireBuffer,
     internalStreamsRequireErrors,
     internalStreamsRequireEventEmitter,
     internalStreamsRequirePrimordials,

--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -2,6 +2,8 @@
 
 const { StringPrototypeSlice, SymbolIterator, TypedArrayPrototypeSet, Uint8Array } = require('../../ours/primordials')
 
+const { Buffer } = require('buffer')
+
 const { inspect } = require('../../ours/util')
 
 module.exports = class BufferList {

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const process = require('process')
+/* replacement end */
+
+;('use strict')
 
 const {
   aggregateTwoErrors,

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,8 +1,9 @@
+'use strict'
+
 /* replacement start */
+
 const process = require('process')
 /* replacement end */
-
-;('use strict')
 
 const {
   aggregateTwoErrors,

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const process = require('process')
+/* replacement end */
+
+;('use strict')
 
 const bufferModule = require('buffer')
 

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -1,6 +1,10 @@
+/* replacement start */
+const process = require('process')
+/* replacement end */
 // Ported from https://github.com/mafintosh/end-of-stream with
 // permission from the author, Mathias Buus (@mafintosh).
-'use strict'
+
+;('use strict')
 
 const { AbortError, codes } = require('../../ours/errors')
 

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -1,6 +1,12 @@
-'use strict'
+/* replacement start */
+const process = require('process')
+/* replacement end */
+
+;('use strict')
 
 const { PromisePrototypeThen, SymbolAsyncIterator, SymbolIterator } = require('../../ours/primordials')
+
+const { Buffer } = require('buffer')
 
 const { ERR_INVALID_ARG_TYPE, ERR_STREAM_NULL_VALUES } = require('../../ours/errors').codes
 

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -1,8 +1,9 @@
+'use strict'
+
 /* replacement start */
+
 const process = require('process')
 /* replacement end */
-
-;('use strict')
 
 const { PromisePrototypeThen, SymbolAsyncIterator, SymbolIterator } = require('../../ours/primordials')
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -1,6 +1,10 @@
+/* replacement start */
+const process = require('process')
+/* replacement end */
 // Ported from https://github.com/mafintosh/pump with
 // permission from the author, Mathias Buus (@mafintosh).
-'use strict'
+
+;('use strict')
 
 const { ArrayIsArray, Promise, SymbolAsyncIterator } = require('../../ours/primordials')
 

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1,3 +1,6 @@
+/* replacement start */
+const process = require('process')
+/* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -18,7 +21,8 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-'use strict'
+
+;('use strict')
 
 const {
   ArrayPrototypeIndexOf,
@@ -40,6 +44,8 @@ Readable.ReadableState = ReadableState
 const { EventEmitter: EE } = require('events')
 
 const { Stream, prependListener } = require('./legacy')
+
+const { Buffer } = require('buffer')
 
 const { addAbortSignal } = require('./add-abort-signal')
 

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -1,3 +1,6 @@
+/* replacement start */
+const process = require('process')
+/* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -21,7 +24,8 @@
 // A bit simpler than readable streams.
 // Implement an async ._write(chunk, encoding, cb), and it'll handle all
 // the drain event emission and buffering.
-'use strict'
+
+;('use strict')
 
 const {
   ArrayPrototypeSlice,
@@ -41,6 +45,8 @@ Writable.WritableState = WritableState
 const { EventEmitter: EE } = require('events')
 
 const Stream = require('./legacy').Stream
+
+const { Buffer } = require('buffer')
 
 const destroyImpl = require('./destroy')
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,3 +1,6 @@
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -18,7 +21,8 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-'use strict'
+
+;('use strict')
 
 const { ObjectDefineProperty, ObjectKeys, ReflectApply } = require('./ours/primordials')
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "abort-controller": "^3.0.0"
+    "abort-controller": "^3.0.0",
+    "buffer": "^6.0.3",
+    "events": "^3.3.0",
+    "process": "^0.11.10"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
@@ -55,7 +58,6 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@sinonjs/fake-timers": "^9.1.2",
     "browserify": "^17.0.0",
-    "buffer-es6": "^4.9.3",
     "c8": "^7.11.2",
     "esbuild": "^0.14.39",
     "esbuild-plugin-alias": "^0.2.1",
@@ -66,7 +68,6 @@
     "eslint-plugin-promise": "^6.0.0",
     "playwright": "^1.21.1",
     "prettier": "^2.6.2",
-    "process-es6": "^0.11.6",
     "rollup": "^2.72.1",
     "rollup-plugin-polyfill-node": "^0.9.0",
     "tap": "^16.2.0",

--- a/process
+++ b/process
@@ -1,0 +1,3 @@
+// workaround for browserify bug: https://github.com/browserify/browserify/issues/1986
+
+module.exports = require('./node_modules/process')

--- a/src/test/browser/fixtures/esbuild-browsers-shims.mjs
+++ b/src/test/browser/fixtures/esbuild-browsers-shims.mjs
@@ -1,8 +1,6 @@
-import * as bufferModule from 'buffer-es6'
-import * as processModule from 'process-es6'
+import * as processModule from 'process'
 
 export const process = processModule
-export const Buffer = bufferModule.Buffer
 
 export function setImmediate(fn, ...args) {
   setTimeout(() => fn(...args), 1)

--- a/src/test/browser/fixtures/rollup.browser.config.mjs
+++ b/src/test/browser/fixtures/rollup.browser.config.mjs
@@ -16,8 +16,7 @@ export default {
     commonjs(),
     nodePolyfill(),
     inject({
-      process: resolve('node_modules/process-es6/browser.js'),
-      Buffer: [resolve('node_modules/buffer-es6/index.js'), 'Buffer']
+      process: resolve('node_modules/process/browser.js')
     }),
     nodeResolve({
       browser: true,

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -21,8 +21,7 @@ export default {
       raw: true
     }),
     new webpack.ProvidePlugin({
-      process: require.resolve('process-es6'),
-      Buffer: [require.resolve('buffer-es6'), 'Buffer']
+      process: require.resolve('process')
     })
   ],
   resolve: {

--- a/test/browser/fixtures/esbuild-browsers-shims.mjs
+++ b/test/browser/fixtures/esbuild-browsers-shims.mjs
@@ -1,8 +1,6 @@
-import * as bufferModule from 'buffer-es6'
-import * as processModule from 'process-es6'
+import * as processModule from 'process'
 
 export const process = processModule
-export const Buffer = bufferModule.Buffer
 
 export function setImmediate(fn, ...args) {
   setTimeout(() => fn(...args), 1)

--- a/test/browser/fixtures/rollup.browser.config.mjs
+++ b/test/browser/fixtures/rollup.browser.config.mjs
@@ -16,8 +16,7 @@ export default {
     commonjs(),
     nodePolyfill(),
     inject({
-      process: resolve('node_modules/process-es6/browser.js'),
-      Buffer: [resolve('node_modules/buffer-es6/index.js'), 'Buffer']
+      process: resolve('node_modules/process/browser.js')
     }),
     nodeResolve({
       browser: true,

--- a/test/browser/fixtures/webpack.browser.config.mjs
+++ b/test/browser/fixtures/webpack.browser.config.mjs
@@ -21,8 +21,7 @@ export default {
       raw: true
     }),
     new webpack.ProvidePlugin({
-      process: require.resolve('process-es6'),
-      Buffer: [require.resolve('buffer-es6'), 'Buffer']
+      process: require.resolve('process')
     })
   ],
   resolve: {

--- a/test/browser/test-stream-big-packet.js
+++ b/test/browser/test-stream-big-packet.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream-big-packet.js
+++ b/test/browser/test-stream-big-packet.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream-pipe-cleanup-pause.js
+++ b/test/browser/test-stream-pipe-cleanup-pause.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const stream = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-pipe-cleanup-pause.js
+++ b/test/browser/test-stream-pipe-cleanup-pause.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const stream = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-pipeline.js
+++ b/test/browser/test-stream-pipeline.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable, Writable, pipeline } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-pipeline.js
+++ b/test/browser/test-stream-pipeline.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable, Writable, pipeline } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-readable-event.js
+++ b/test/browser/test-stream-readable-event.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-readable-event.js
+++ b/test/browser/test-stream-readable-event.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-transform-constructor-set-methods.js
+++ b/test/browser/test-stream-transform-constructor-set-methods.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Transform } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-transform-constructor-set-methods.js
+++ b/test/browser/test-stream-transform-constructor-set-methods.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Transform } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-transform-split-objectmode.js
+++ b/test/browser/test-stream-transform-split-objectmode.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Transform } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-transform-split-objectmode.js
+++ b/test/browser/test-stream-transform-split-objectmode.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Transform } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-unshift-empty-chunk.js
+++ b/test/browser/test-stream-unshift-empty-chunk.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-unshift-empty-chunk.js
+++ b/test/browser/test-stream-unshift-empty-chunk.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-unshift-read-race.js
+++ b/test/browser/test-stream-unshift-read-race.js
@@ -1,4 +1,8 @@
-'use strict' // This test verifies that:
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict') // This test verifies that:
 // 1. unshift() does not cause colliding _read() calls.
 // 2. unshift() after the 'end' event is an error, but after the EOF
 //    signalling null, it is ok, and just creates a new readable chunk.

--- a/test/browser/test-stream-unshift-read-race.js
+++ b/test/browser/test-stream-unshift-read-race.js
@@ -1,8 +1,9 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict') // This test verifies that:
+// This test verifies that:
 // 1. unshift() does not cause colliding _read() calls.
 // 2. unshift() after the 'end' event is an error, but after the EOF
 //    signalling null, it is ok, and just creates a new readable chunk.

--- a/test/browser/test-stream-writable-change-default-encoding.js
+++ b/test/browser/test-stream-writable-change-default-encoding.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream-writable-change-default-encoding.js
+++ b/test/browser/test-stream-writable-change-default-encoding.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream-writable-constructor-set-methods.js
+++ b/test/browser/test-stream-writable-constructor-set-methods.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Writable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-writable-constructor-set-methods.js
+++ b/test/browser/test-stream-writable-constructor-set-methods.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Writable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-writable-decoded-encoding.js
+++ b/test/browser/test-stream-writable-decoded-encoding.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream-writable-decoded-encoding.js
+++ b/test/browser/test-stream-writable-decoded-encoding.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream-writev.js
+++ b/test/browser/test-stream-writev.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const stream = require('../../lib/ours/index')
 

--- a/test/browser/test-stream-writev.js
+++ b/test/browser/test-stream-writev.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const stream = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-base64-single-char-read-end.js
+++ b/test/browser/test-stream2-base64-single-char-read-end.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable, Writable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-base64-single-char-read-end.js
+++ b/test/browser/test-stream2-base64-single-char-read-end.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable, Writable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-compatibility.js
+++ b/test/browser/test-stream2-compatibility.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream2-compatibility.js
+++ b/test/browser/test-stream2-compatibility.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream2-large-read-stall.js
+++ b/test/browser/test-stream2-large-read-stall.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-large-read-stall.js
+++ b/test/browser/test-stream2-large-read-stall.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-pipe-error-handling.js
+++ b/test/browser/test-stream2-pipe-error-handling.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const stream = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-pipe-error-handling.js
+++ b/test/browser/test-stream2-pipe-error-handling.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const stream = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/browser/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/browser/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-readable-from-list.js
+++ b/test/browser/test-stream2-readable-from-list.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { _fromList: fromList } = require('../../lib/_stream_readable')
 

--- a/test/browser/test-stream2-readable-from-list.js
+++ b/test/browser/test-stream2-readable-from-list.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { _fromList: fromList } = require('../../lib/_stream_readable')
 

--- a/test/browser/test-stream2-readable-legacy-drain.js
+++ b/test/browser/test-stream2-readable-legacy-drain.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Stream, Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-readable-legacy-drain.js
+++ b/test/browser/test-stream2-readable-legacy-drain.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Stream, Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-readable-non-empty-end.js
+++ b/test/browser/test-stream2-readable-non-empty-end.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-readable-non-empty-end.js
+++ b/test/browser/test-stream2-readable-non-empty-end.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-readable-wrap.js
+++ b/test/browser/test-stream2-readable-wrap.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { EventEmitter: EE } = require('events')
 

--- a/test/browser/test-stream2-readable-wrap.js
+++ b/test/browser/test-stream2-readable-wrap.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { EventEmitter: EE } = require('events')
 

--- a/test/browser/test-stream2-set-encoding.js
+++ b/test/browser/test-stream2-set-encoding.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream2-set-encoding.js
+++ b/test/browser/test-stream2-set-encoding.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream2-transform.js
+++ b/test/browser/test-stream2-transform.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { PassThrough, Transform } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-transform.js
+++ b/test/browser/test-stream2-transform.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { PassThrough, Transform } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream2-writable.js
+++ b/test/browser/test-stream2-writable.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream2-writable.js
+++ b/test/browser/test-stream2-writable.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const inherits = require('inherits')
 

--- a/test/browser/test-stream3-pause-then-read.js
+++ b/test/browser/test-stream3-pause-then-read.js
@@ -1,4 +1,8 @@
-'use strict'
+/* replacement start */
+const { Buffer } = require('buffer')
+/* replacement end */
+
+;('use strict')
 
 const { Readable, Writable } = require('../../lib/ours/index')
 

--- a/test/browser/test-stream3-pause-then-read.js
+++ b/test/browser/test-stream3-pause-then-read.js
@@ -1,8 +1,8 @@
+'use strict'
 /* replacement start */
+
 const { Buffer } = require('buffer')
 /* replacement end */
-
-;('use strict')
 
 const { Readable, Writable } = require('../../lib/ours/index')
 


### PR DESCRIPTION
The current code requires adding custom configs for bundlers to import Node.js polyfills. This PR removes that requirement.

Polyfills are required directly in the code. This can be done because the Node.js core modules have the same names (`buffer`, `events`, `process`), and therefore, the code modules are used under Node.js. The polyfills are only imported for browser builds.

This required switching from `buffer-es6` to `buffer`, and `process-es6` to `process`. Both packages are more up-to-date than the ones that have been replaced.

Many lines have been touched, but the `lib` folder changes are pretty small. Most changes are related to the test code. The same imports are required, but more files are affected.

Besides the globals `buffer` and `process`, `events` is added as a dependency. No code changes are required in that regard because `events` is not accessible as global, and therefore, `require` calls are already in the current code.
