### PR TITLE
fix: use workaround loading process-shim for browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,27 +87,7 @@ shown in the example above.
 
 ## Usage In Browsers
 
-You will need a bundler like [`browserify`](https://github.com/browserify/browserify#readme), [`webpack`](https://webpack.js.org/), [`parcel`](https://github.com/parcel-bundler/parcel#readme) or similar. With Webpack 5 (which unlike other bundlers does not polyfill Node.js core modules and globals like `process`) you will also need to:
-
-1. Install polyfills by running `npm install buffer process --save-dev`
-2. Create a [`webpack.config.js`](https://webpack.js.org/guides/getting-started/#using-a-configuration) file containing:
-
-```js
-const webpack = require('webpack')
-
-module.exports = {
-  plugins: [
-    new webpack.ProvidePlugin({
-      process: 'process/browser'
-    })
-  ],
-  resolve: {
-    fallback: {
-      buffer: require.resolve('buffer/')
-    }
-  }
-}
-```
+You will need a bundler like [`browserify`](https://github.com/browserify/browserify#readme), [`webpack`](https://webpack.js.org/), [`parcel`](https://github.com/parcel-bundler/parcel#readme) or similar. Polyfills are no longer required since version 4.2.0.
 
 # Streams Working Group
 

--- a/build/headers.mjs
+++ b/build/headers.mjs
@@ -9,7 +9,7 @@ const bufferRequire = `
 const processRequire = `
   /* replacement start */
 
-  const process = require('process')
+  const process = require('process/')
 
   /* replacement end */
 `

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -2,7 +2,7 @@
 
 /* replacement start */
 
-const process = require('process')
+const process = require('process/')
 
 /* replacement end */
 

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process')
+const process = require('process/')
 
 /* replacement end */
 

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process')
+const process = require('process/')
 
 /* replacement end */
 // Ported from https://github.com/mafintosh/end-of-stream with

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -2,7 +2,7 @@
 
 /* replacement start */
 
-const process = require('process')
+const process = require('process/')
 
 /* replacement end */
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process')
+const process = require('process/')
 
 /* replacement end */
 // Ported from https://github.com/mafintosh/pump with

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process')
+const process = require('process/')
 
 /* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process')
+const process = require('process/')
 
 /* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.

--- a/process
+++ b/process
@@ -1,3 +1,0 @@
-// workaround for browserify bug: https://github.com/browserify/browserify/issues/1986
-
-module.exports = require('./node_modules/process')


### PR DESCRIPTION
replaced `require('process')` with `require('process/')` to fix #496

The build step generated quite a big diff. I compared a few samples with the code in the https://github.com/nodejs/node repository, and the generated code looks good to me. I think there was a problem earlier on.

@mcollina Hints on how to solve this are very welcome. Is there a post-process step? Should I create a separate PR just for the diff generated by the build and then fix the process-shim issue?