### PR TITLE
fix: removes `Readable.fromWeb` and `Readable.toWeb` methods 

### DIFF
--- a/build/build.mjs
+++ b/build/build.mjs
@@ -1,5 +1,5 @@
 import { transform } from '@babel/core'
-import { createReadStream, writeFileSync } from 'node:fs'
+import { createReadStream } from 'node:fs'
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
@@ -12,7 +12,7 @@ import prettierConfig from '../prettier.config.cjs'
 import { aliases, skippedSources, sources } from './files.mjs'
 import { footers } from './footers.mjs'
 import { headers } from './headers.mjs'
-import { replacements, removeObsoleteReadableMethods } from './replacements.mjs'
+import { replacements } from './replacements.mjs'
 
 const baseMatcher = /^(?:lib|test)/
 const strictMatcher = /^(['"']use strict.+)/
@@ -171,10 +171,6 @@ async function main() {
   // Cleanup existing folder
   await rm('lib', { recursive: true, force: true })
   await rm('test', { recursive: true, force: true })
-
-  // remove obsolete methods from readable-stream
-  const methodNamesToRemove = ['fromWeb', 'toWeb']
-  await removeObsoleteReadableMethods(methodNamesToRemove)
 
   // Download or open the tar file
   let tarFile

--- a/build/build.mjs
+++ b/build/build.mjs
@@ -12,7 +12,7 @@ import prettierConfig from '../prettier.config.cjs'
 import { aliases, skippedSources, sources } from './files.mjs'
 import { footers } from './footers.mjs'
 import { headers } from './headers.mjs'
-import { replacements } from './replacements.mjs'
+import { replacements, removeObsoleteReadableMethods } from './replacements.mjs'
 
 const baseMatcher = /^(?:lib|test)/
 const strictMatcher = /^(['"']use strict.+)/
@@ -173,15 +173,8 @@ async function main() {
   await rm('test', { recursive: true, force: true })
 
   // remove obsolete methods from readable-stream
-  const methodNameToRemove = ['fromWeb', 'toWeb']
-  const readableStreamPath = resolve(__dirname, '../lib/internal/streams/readable.js')
-  let readableStreamContent = await readFile(readableStreamPath, 'utf-8')
-
-  for (const method of methodNameToRemove) {
-    const regex = new RegExp(`Readable.+${method} = function\\s\\s*\\([^)]*\\)\\s*{[^}]*}`, 'g')
-    readableStreamContent = readableStreamContent.replace(regex, '')
-    writeFileSync(readableStreamPath, readableStreamContent, 'utf8')
-  }
+  const methodNamesToRemove = ['fromWeb', 'toWeb']
+  await removeObsoleteReadableMethods(methodNamesToRemove)
 
   // Download or open the tar file
   let tarFile

--- a/build/replacements.mjs
+++ b/build/replacements.mjs
@@ -1,7 +1,3 @@
-import { resolve } from 'node:path'
-import { writeFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
-
 const legacyStreamsRequireStream = ["require\\('stream'\\)", "require('./stream')"]
 
 const internalStreamsBufferPolyfill = [
@@ -156,17 +152,6 @@ const testParallelIncludeTap = [
 
 const testParallelImportStreamInMjs = [" from 'stream';", "from '../../lib/ours/index.js';"]
 
-export const removeObsoleteReadableMethods = async function(methodNames) {
-  const readableStreamPath = resolve(__dirname, '../lib/internal/streams/readable.js')
-  let readableStreamContent = await readFile(readableStreamPath, 'utf-8')
-
-  for (const method of methodNames) {
-    const regex = new RegExp(`Readable.+${method} = function\\s\\s*\\([^)]*\\)\\s*{[^}]*}`, 'g')
-    readableStreamContent = readableStreamContent.replace(regex, '')
-    writeFileSync(readableStreamPath, readableStreamContent, 'utf8')
-  }
-}
-
 const testParallelImportTapInMjs = ["(from 'assert';)", "$1\nimport tap from 'tap';"]
 
 const testParallelDuplexFromBlob = [
@@ -231,6 +216,10 @@ const testParallelTicksReenableConsoleLog = ['silentConsole.log\\(i\\);', 'conso
 
 const testParallelTickSaveHook = ['async_hooks.createHook\\(\\{', 'const hook = async_hooks.createHook({']
 
+const removefromWebReadableMethod = ['Readable.fromWeb = function\\s\\s*\\([^)]*\\)\\s*{[^}]*}', '']
+
+const removetoWebReadableMethod = ['Readable.toWeb = function\\s\\s*\\([^)]*\\)\\s*{[^}]*}', '']
+
 const readmeInfo = ['(This package is a mirror of the streams implementations in Node.js) (\\d+.\\d+.\\d+).', '$1 $2.']
 
 const readmeLink = ['(\\[Node.js website\\]\\(https://nodejs.org/dist/v)(\\d+.\\d+.\\d+)', '$1$2']
@@ -246,6 +235,10 @@ export const replacements = {
   'lib/internal/streams/(operators|pipeline).+': [
     internalStreamsAbortControllerPolyfill,
     internalStreamsNoRequireAbortController
+  ],
+  'lib/internal/streams/readable.js': [
+    removefromWebReadableMethod,
+    removetoWebReadableMethod
   ],
   'lib/internal/streams/.+': [
     internalStreamsRequireErrors,

--- a/build/replacements.mjs
+++ b/build/replacements.mjs
@@ -1,3 +1,7 @@
+import { resolve } from 'node:path'
+import { writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+
 const legacyStreamsRequireStream = ["require\\('stream'\\)", "require('./stream')"]
 
 const internalStreamsBufferPolyfill = [
@@ -151,6 +155,17 @@ const testParallelIncludeTap = [
 ]
 
 const testParallelImportStreamInMjs = [" from 'stream';", "from '../../lib/ours/index.js';"]
+
+export const removeObsoleteReadableMethods = async function(methodNames) {
+  const readableStreamPath = resolve(__dirname, '../lib/internal/streams/readable.js')
+  let readableStreamContent = await readFile(readableStreamPath, 'utf-8')
+
+  for (const method of methodNames) {
+    const regex = new RegExp(`Readable.+${method} = function\\s\\s*\\([^)]*\\)\\s*{[^}]*}`, 'g')
+    readableStreamContent = readableStreamContent.replace(regex, '')
+    writeFileSync(readableStreamPath, readableStreamContent, 'utf8')
+  }
+}
 
 const testParallelImportTapInMjs = ["(from 'assert';)", "$1\nimport tap from 'tap';"]
 


### PR DESCRIPTION
fixes: https://github.com/nodejs/readable-stream/issues/482

The `Readable.fromWeb` and `Readable.toWeb` methods were no longer being used from here (instead being imported from `require(stream')` method).

This pr removes both methods during the build when the module is extracted from Node.js.