### PR TITLE
chore: don't polyfill stream in webpack.browser.config.mjs

### DIFF
--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -20,15 +20,8 @@ export default {
       banner: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 1) }',
       raw: true
     }),
-    new webpack.ProvidePlugin({
-      process: require.resolve('process')
-    })
   ],
   resolve: {
     aliasFields: ['browser'],
-    fallback: {
-      crypto: require.resolve('crypto-browserify'),
-      path: require.resolve('path-browserify')
-    }
   }
 }

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -28,8 +28,7 @@ export default {
     aliasFields: ['browser'],
     fallback: {
       crypto: require.resolve('crypto-browserify'),
-      path: require.resolve('path-browserify'),
-      stream: require.resolve('stream-browserify')
+      path: require.resolve('path-browserify')
     }
   }
 }

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -13,6 +13,6 @@ export default {
   target: 'web',
   performance: false,
   resolve: {
-    aliasFields: ['browser'],
+    aliasFields: ['browser']
   }
 }

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -1,9 +1,6 @@
-import { createRequire } from 'module'
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
-import webpack from 'webpack'
 
-const require = createRequire(import.meta.url)
 const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../')
 
 export default {
@@ -15,12 +12,6 @@ export default {
   mode: 'production',
   target: 'web',
   performance: false,
-  plugins: [
-    new webpack.BannerPlugin({
-      banner: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 1) }',
-      raw: true
-    }),
-  ],
   resolve: {
     aliasFields: ['browser'],
   }

--- a/test/browser/fixtures/webpack.config.mjs
+++ b/test/browser/fixtures/webpack.config.mjs
@@ -1,0 +1,13 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../')
+
+export default {
+  mode: 'development',
+  entry: './test/browser/import-all.js',
+  output: {
+    path: resolve(rootDir, 'tmp/webpack'),
+    filename: 'import-all.js'
+  }
+}

--- a/test/browser/import-all.js
+++ b/test/browser/import-all.js
@@ -1,1 +1,2 @@
 import * as all from '../../lib/ours'
+import * as allBrowser from '../../lib/ours/browser'

--- a/test/browser/import-all.js
+++ b/test/browser/import-all.js
@@ -1,0 +1,1 @@
+import * as all from '../../lib/ours'

--- a/test/browser/runner-prepare.mjs
+++ b/test/browser/runner-prepare.mjs
@@ -98,6 +98,7 @@ async function main() {
     case 'webpack':
       await run('webpack -c test/browser/fixtures/webpack.browser.config.mjs')
       await run('webpack -c test/browser/fixtures/webpack.node.config.mjs')
+      await run('webpack -c test/browser/fixtures/webpack.config.mjs')
   }
 }
 


### PR DESCRIPTION
This PR does 2 things:
 - Cleans up the existing webpack browser config by removing alias' and plugins that are no longer required.
 - Tests for regression in #516 by adding a new webpack config to import what is effectively the file `import * as all from 'readable-stream'`