### PR TITLE
fix: remove unused `require('stream')` and extend webpack tests

### DIFF
--- a/lib/stream/promises.js
+++ b/lib/stream/promises.js
@@ -4,7 +4,7 @@ const { ArrayPrototypePop, Promise } = require('../ours/primordials')
 const { isIterable, isNodeStream, isWebStream } = require('../internal/streams/utils')
 const { pipelineImpl: pl } = require('../internal/streams/pipeline')
 const { finished } = require('../internal/streams/end-of-stream')
-require('stream')
+
 function pipeline(...streams) {
   return new Promise((resolve, reject) => {
     let signal

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -20,15 +20,8 @@ export default {
       banner: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 1) }',
       raw: true
     }),
-    new webpack.ProvidePlugin({
-      process: require.resolve('process')
-    })
   ],
   resolve: {
     aliasFields: ['browser'],
-    fallback: {
-      crypto: require.resolve('crypto-browserify'),
-      path: require.resolve('path-browserify')
-    }
   }
 }

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -28,8 +28,7 @@ export default {
     aliasFields: ['browser'],
     fallback: {
       crypto: require.resolve('crypto-browserify'),
-      path: require.resolve('path-browserify'),
-      stream: require.resolve('stream-browserify')
+      path: require.resolve('path-browserify')
     }
   }
 }

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -13,6 +13,6 @@ export default {
   target: 'web',
   performance: false,
   resolve: {
-    aliasFields: ['browser'],
+    aliasFields: ['browser']
   }
 }

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -1,9 +1,6 @@
-import { createRequire } from 'module'
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
-import webpack from 'webpack'
 
-const require = createRequire(import.meta.url)
 const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../')
 
 export default {
@@ -15,12 +12,6 @@ export default {
   mode: 'production',
   target: 'web',
   performance: false,
-  plugins: [
-    new webpack.BannerPlugin({
-      banner: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 1) }',
-      raw: true
-    }),
-  ],
   resolve: {
     aliasFields: ['browser'],
   }

--- a/test/browser/fixtures/webpack.config.mjs
+++ b/test/browser/fixtures/webpack.config.mjs
@@ -1,0 +1,13 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../')
+
+export default {
+  mode: 'development',
+  entry: './test/browser/import-all.js',
+  output: {
+    path: resolve(rootDir, 'tmp/webpack'),
+    filename: 'import-all.js'
+  }
+}

--- a/test/browser/import-all.js
+++ b/test/browser/import-all.js
@@ -1,1 +1,2 @@
 import * as all from '../../lib/ours'
+import * as allBrowser from '../../lib/ours/browser'

--- a/test/browser/import-all.js
+++ b/test/browser/import-all.js
@@ -1,0 +1,1 @@
+import * as all from '../../lib/ours'

--- a/test/browser/runner-prepare.mjs
+++ b/test/browser/runner-prepare.mjs
@@ -98,6 +98,7 @@ async function main() {
     case 'webpack':
       await run('webpack -c test/browser/fixtures/webpack.browser.config.mjs')
       await run('webpack -c test/browser/fixtures/webpack.node.config.mjs')
+      await run('webpack -c test/browser/fixtures/webpack.config.mjs')
   }
 }
 


### PR DESCRIPTION
Closes #516 

Potentially supercedes #517 by also including a fix; which is removing `require('stream')` in https://github.com/jeswr/readable-stream/blob/3caace80d34bacaeb3d2aa760f3bd0fbdd9ae3d3/lib/stream/promises.js.

However [this comment](https://github.com/nodejs/readable-stream/pull/517#issuecomment-1547427364) makes me suspicious of whether this one-liner is the desired fix - hence why I have opened this as a separate PR.

