### PR TITLE
fix: don't require `stream` package in codebase

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -38,5 +38,7 @@ jobs:
         run: ./node_modules/.bin/playwright install ${{ fromJSON('{"chrome":"chromium","edge":"msedge","firefox":"firefox","safari":"webkit"}')[matrix.browser] }}
       - name: Bundle code
         run: npm run test:prepare ${{ matrix.bundler }}
+      - name: Bundle readable-stream code with readable-stream specific bundlers
+        run: npm run test:readable-stream-only ${{ matrix.bundler }}
       - name: Run Tests on Browsers
         run: npm run test:browsers ${{ matrix.browser }} ${{ matrix.bundler }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 node-*.tar.gz
 package-lock.json
 tmp/
+readable-stream-test/dist/

--- a/build/replacements.mjs
+++ b/build/replacements.mjs
@@ -236,6 +236,8 @@ const readmeInfo = ['(This package is a mirror of the streams implementations in
 
 const readmeLink = ['(\\[Node.js website\\]\\(https://nodejs.org/dist/v)(\\d+.\\d+.\\d+)', '$1$2']
 
+const streamRequire = [ "require\\('stream'\\)", "require('../../lib/stream.js')" ]
+
 export const replacements = {
   'lib/_stream.+': [legacyStreamsRequireStream],
   'lib/internal/streams/duplexify.+': [
@@ -288,7 +290,7 @@ export const replacements = {
     streamIndexRequireUtil,
     streamIndexRequireInternal
   ],
-  'lib/stream/.+': [streamsRequireErrors, streamsRequirePrimordials, streamsRequireInternal],
+  'lib/stream/.+': [streamsRequireErrors, streamsRequirePrimordials, streamsRequireInternal, streamRequire],
   'test/common/index.js': [testCommonKnownGlobals],
   'test/parallel/.+': [
     testParallelIncludeTap,

--- a/lib/stream/promises.js
+++ b/lib/stream/promises.js
@@ -4,7 +4,7 @@ const { ArrayPrototypePop, Promise } = require('../ours/primordials')
 const { isIterable, isNodeStream, isWebStream } = require('../internal/streams/utils')
 const { pipelineImpl: pl } = require('../internal/streams/pipeline')
 const { finished } = require('../internal/streams/end-of-stream')
-require('stream')
+require('../../lib/stream.js')
 function pipeline(...streams) {
   return new Promise((resolve, reject) => {
     let signal

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:prepare": "node test/browser/runner-prepare.mjs",
     "test:browsers": "node test/browser/runner-browser.mjs",
     "test:bundlers": "node test/browser/runner-node.mjs",
+    "test:readable-stream-only": "node readable-stream-test/runner-prepare.mjs",
     "coverage": "c8 -c ./c8.json tap --rcfile=./tap.yml test/parallel/test-*.js test/ours/test-*.js",
     "format": "prettier -w src lib test",
     "lint": "eslint src"

--- a/readable-stream-test/import.js
+++ b/readable-stream-test/import.js
@@ -1,0 +1,3 @@
+import * as all from '../lib/ours'
+import * as allBrowser from '../lib/ours/browser'
+import * as allRoot from '../lib/ours'

--- a/readable-stream-test/runner-prepare.mjs
+++ b/readable-stream-test/runner-prepare.mjs
@@ -72,6 +72,6 @@ async function main() {
 }
 
 main().catch((e) => {
-  process.error(e)
+  error(e)
   process.exit(1)
 })

--- a/readable-stream-test/runner-prepare.mjs
+++ b/readable-stream-test/runner-prepare.mjs
@@ -1,0 +1,77 @@
+import { exec } from 'child_process'
+import util from '../lib/ours/util.js'
+
+function info(message) {
+  console.log(`\x1b[34m[INFO]\x1b[0m ${message}`)
+}
+
+function error(message) {
+  console.log(`\x1b[31m[INFO]\x1b[0m ${message}`)
+}
+
+async function run(command) {
+  info(`Executing \x1b[33m${command}\x1b[0m ...`)
+  const { promise, reject, resolve } = util.createDeferredPromise()
+
+  let hasOutput = false
+  function logOutput(chunk) {
+    if (!hasOutput) {
+      hasOutput = true
+      console.log('')
+    }
+
+    console.log(chunk.toString('utf-8').trim().replace(/^/gm, '       '))
+  }
+
+  try {
+    const process = exec(command, { stdio: 'pipe' }, (error) => {
+      if (error) {
+        return reject(error)
+      }
+
+      resolve(error)
+    })
+
+    process.stdout.on('data', logOutput)
+    process.stderr.on('data', logOutput)
+    await promise
+
+    if (hasOutput) {
+      console.log('')
+    }
+  } catch (e) {
+    if (hasOutput) {
+      console.log('')
+    }
+
+    error(`Command failed with status code ${e.code}.`)
+    process.exit(1)
+  }
+}
+
+async function main() {
+  const validBundlers = ['browserify', 'esbuild', 'rollup', 'webpack']
+  const bundler = process.argv[2] || process.env.BUNDLER
+
+  if (!validBundlers.includes(bundler)) {
+    error(`Usage: node await runner-prepare.mjs [${validBundlers.join('|')}]`)
+    error('You can also use the BUNDLER environment variable.')
+    process.exit(1)
+  }
+
+  switch (bundler) {
+    case 'browserify':
+      break
+    case 'esbuild':
+      break
+    case 'rollup':
+      break
+    case 'webpack':
+      await run('webpack -c readable-stream-test/webpack.config.mjs')
+  }
+}
+
+main().catch((e) => {
+  process.error(e)
+  process.exit(1)
+})

--- a/readable-stream-test/webpack.config.mjs
+++ b/readable-stream-test/webpack.config.mjs
@@ -1,0 +1,13 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../')
+
+export default {
+  mode: 'development',
+  entry: './readable-stream-test/import.js',
+  output: {
+    path: resolve(rootDir, 'bundling', 'dist'),
+    filename: 'import.js'
+  }
+}

--- a/readable-stream-test/webpack.config.mjs
+++ b/readable-stream-test/webpack.config.mjs
@@ -1,13 +1,13 @@
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
 
-const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../')
+const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '../')
 
 export default {
   mode: 'development',
   entry: './readable-stream-test/import.js',
   output: {
-    path: resolve(rootDir, 'bundling', 'dist'),
+    path: resolve(rootDir, 'readable-stream-test', 'dist'),
     filename: 'import.js'
   }
 }


### PR DESCRIPTION
Closes #516.

Supercedes #517 and #519.

This replaces `require('stream')` with `require('../../lib/stream.js')` in the build script so that the `stream` module is never imported.

Since #517 I've moved the regression test to a new folder in the root since the other test fixtures are being copied from the nodejs codebase; wheras the one I add is specific to `readable-stream`.