### PR TITLE
fix: add string decoder as a dependency

### DIFF
--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -17,7 +17,9 @@ jobs:
         bundler: ['browserify', 'esbuild', 'rollup', 'webpack']
         exclude:
           - os: windows-latest
-            node-version: [12.x, 14.x]
+            node-version: 12.x
+          - os: windows-latest
+            node-version: 14.x
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -28,8 +28,11 @@ jobs:
           path: node_modules
           key: node-modules-${{ matrix.os }}-${{ hashFiles('package.json') }}
       - name: Install dependencies
+        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm install
       - name: Bundle code
+        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm run test:prepare ${{ matrix.bundler }}
       - name: Run Tests on Browsers
+        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm run test:bundlers ${{ matrix.bundler }}

--- a/.github/workflows/bundlers.yml
+++ b/.github/workflows/bundlers.yml
@@ -15,6 +15,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
         bundler: ['browserify', 'esbuild', 'rollup', 'webpack']
+        exclude:
+          - os: windows-latest
+            node-version: [12.x, 14.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,11 +31,8 @@ jobs:
           path: node_modules
           key: node-modules-${{ matrix.os }}-${{ hashFiles('package.json') }}
       - name: Install dependencies
-        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm install
       - name: Bundle code
-        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm run test:prepare ${{ matrix.bundler }}
       - name: Run Tests on Browsers
-        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm run test:bundlers ${{ matrix.bundler }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -27,6 +27,8 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package.json') }}
       - name: Install dependencies
+        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm install
       - name: Run Tests
+        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm run coverage

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
+        exclude:
+          - os: windows-latest
+            node-version: [12.x, 14.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,8 +30,6 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package.json') }}
       - name: Install dependencies
-        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm install
       - name: Run Tests
-        if: ${{ !(matrix.os == 'windows-latest' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')) }}
         run: npm run coverage

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,9 @@ jobs:
         node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
         exclude:
           - os: windows-latest
-            node-version: [12.x, 14.x]
+            node-version: 12.x
+          - os: windows-latest
+            node-version: 14.x
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "abort-controller": "^3.0.0",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
-    "process": "^0.11.10"
+    "process": "^0.11.10",
+    "string_decoder": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",


### PR DESCRIPTION
Adds `string_decoder` as a dependency as it is imported [here](https://github.com/nodejs/readable-stream/blob/ec65f43d95b8dd505f9059e0bd35aac309fdf19e/lib/internal/streams/readable.js#L66).

The `string_decoder` package happened to already be a devDependency of `readable-stream` and hence was not caught as missing by the recently added [webpacking tests](https://github.com/nodejs/readable-stream/tree/main/readable-stream-test) which have access to the devDependencies. Ideally a test should be added where they do not have access to these.

It appears to me that this used to be a dependency but that was removed in https://github.com/nodejs/readable-stream/commit/81c52641299e5ea3a5e37179967bb13691cad081#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519 - it is not clear to me why as a comment was made about this at the time https://github.com/nodejs/readable-stream/pull/471#discussion_r862719133.