### PR TITLE
Circumvent issues with ESM process polyfills

### DIFF
--- a/lib/internal/patches/process.js
+++ b/lib/internal/patches/process.js
@@ -1,0 +1,27 @@
+/* wraps the internal process module, circumventing issues with some polyfills (see #539) */
+
+/** @type {import('node:process')} */
+const process = ((base, esmKey, keys, isValid) => {
+  // check if top-level es module, in which case it may have a default export
+  if (esmKey in base && base[esmKey] === true) {
+    let candidate
+    for (const key of keys) {
+      if (!(key in base)) {
+        continue
+      }
+      candidate = base[key]
+      // sanity check
+      if (isValid(candidate)) {
+        return candidate
+      }
+    }
+  }
+  return base
+})(
+  require('process/'),
+  '__esModule',
+  ['default', 'process'],
+  (candidate) => 'nextTick' in candidate
+)
+
+module.exports = process

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -2,7 +2,7 @@
 
 /* replacement start */
 
-const process = require('process/')
+const process = require('../patches/process')
 
 /* replacement end */
 

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process/')
+const process = require('../patches/process')
 
 /* replacement end */
 

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process/')
+const process = require('../patches/process')
 
 /* replacement end */
 // Ported from https://github.com/mafintosh/end-of-stream with

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -2,7 +2,7 @@
 
 /* replacement start */
 
-const process = require('process/')
+const process = require('../patches/process')
 
 /* replacement end */
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process/')
+const process = require('../patches/process')
 
 /* replacement end */
 // Ported from https://github.com/mafintosh/pump with

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process/')
+const process = require('../patches/process')
 
 /* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -1,6 +1,6 @@
 /* replacement start */
 
-const process = require('process/')
+const process = require('../patches/process')
 
 /* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.


### PR DESCRIPTION
Would resolve #539. A hacky solution that may preferrably be made obsolete by resolution of [davidmyersdev/vite-plugin-node-polyfills#106](https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/106).

The root issue is that some ``node:process`` polyfills export an ES module that is not unwrapped at runtime. This change would introduce a patch that conditionally unwraps the module in the event that checks pass indicating that it is wrapped. Those checks are:
- ``require("node:process")["__esModule"] === true``
  - Intent is to quickly eliminate false positives
- ``"nextTick" in require("node:process")["default"] || "nextTick" in require("node:process")["process"]``
  - Indicates that the ``default`` or ``process`` property of the import is indeed intended to polyfill ``node:process``. The choice of ``nextTick`` here is arbitrary, however the method would be required for proper function of this package.

This also inherits the curioisty introduced by #497 where ``node:process`` is imported via ``process/``.