### PR TITLE
fix: `internalStreamsWeakHandler` replacement rule

### DIFF
--- a/build/replacements.mjs
+++ b/build/replacements.mjs
@@ -81,7 +81,7 @@ const internalStreamsRequireWebStream = ["require\\('internal/webstreams/adapter
 
 const internalStreamsWeakHandler = [
   "const \\{ kWeakHandler \\} = require\\('../event_target'\\);",
-  "require\\('../event_target'\\);const kWeakHandler = require('../../ours/primordials').Symbol('kWeak');"
+  "require('../event_target');const kWeakHandler = require('../../ours/primordials').Symbol('kWeak');"
 ]
 
 const internalStreamsWeakHandler2 = [


### PR DESCRIPTION
The replacement part of the rule incorrectly contains the escape `\\`, probably copy-pasted from the pattern part. Fix is to just remove it.