### PR TITLE
Update build for #542

### DIFF
--- a/build/build.mjs
+++ b/build/build.mjs
@@ -195,6 +195,7 @@ async function main() {
   contents.push(['lib/ours/errors.js', await readFile('src/errors.js', 'utf-8')])
   contents.push(['lib/ours/primordials.js', await readFile('src/primordials.js', 'utf-8')])
   contents.push(['lib/ours/util.js', await readFile('src/util.js', 'utf-8')])
+  contents.push(['lib/ours/util/inspect.js', await readFile('src/util/inspect.js', 'utf-8')])
 
   for (const file of await readdir('src/test/ours')) {
     contents.push([`test/ours/${file}`, await readFile(`src/test/ours/${file}`, 'utf-8')])

--- a/build/build.mjs
+++ b/build/build.mjs
@@ -15,7 +15,7 @@ import { headers } from './headers.mjs'
 import { replacements } from './replacements.mjs'
 
 const baseMatcher = /^(?:lib|test)/
-const strictMatcher = /^(['"']use strict.+)/
+const strictMatcher = /^(['"]use strict.+)/m
 
 function highlightFile(file, color) {
   return `\x1b[${color}m${file.replace(process.cwd() + '/', '')}\x1b[0m`

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -1,12 +1,14 @@
+// Ported from https://github.com/mafintosh/end-of-stream with
+// permission from the author, Mathias Buus (@mafintosh).
+
+'use strict'
+
 /* replacement start */
 
 const process = require('process/')
 
 /* replacement end */
-// Ported from https://github.com/mafintosh/end-of-stream with
-// permission from the author, Mathias Buus (@mafintosh).
 
-;('use strict')
 const { AbortError, codes } = require('../../ours/errors')
 const { ERR_INVALID_ARG_TYPE, ERR_STREAM_PREMATURE_CLOSE } = codes
 const { kEmptyObject, once } = require('../../ours/util')

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1,8 +1,3 @@
-/* replacement start */
-
-const process = require('process/')
-
-/* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,7 +19,14 @@ const process = require('process/')
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-;('use strict')
+'use strict'
+
+/* replacement start */
+
+const process = require('process/')
+
+/* replacement end */
+
 const {
   ArrayPrototypeIndexOf,
   NumberIsInteger,

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -1,8 +1,3 @@
-/* replacement start */
-
-const process = require('process/')
-
-/* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -28,7 +23,14 @@ const process = require('process/')
 // Implement an async ._write(chunk, encoding, cb), and it'll handle all
 // the drain event emission and buffering.
 
-;('use strict')
+'use strict'
+
+/* replacement start */
+
+const process = require('process/')
+
+/* replacement end */
+
 const {
   ArrayPrototypeSlice,
   Error,

--- a/lib/ours/errors.js
+++ b/lib/ours/errors.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { format, inspect, AggregateError: CustomAggregateError } = require('./util')
+const { format, inspect } = require('./util/inspect')
+const { AggregateError: CustomAggregateError } = require('./util')
 
 /*
   This file is a reduced and adapted version of the main lib/internal/errors.js file defined at

--- a/lib/ours/errors.js
+++ b/lib/ours/errors.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { format, inspect } = require('./util/inspect')
-const { AggregateError: CustomAggregateError } = require('./util')
+const { AggregateError: CustomAggregateError } = require('./primordials')
 
 /*
   This file is a reduced and adapted version of the main lib/internal/errors.js file defined at

--- a/lib/ours/errors.js
+++ b/lib/ours/errors.js
@@ -6,7 +6,7 @@ const { AggregateError: CustomAggregateError } = require('./primordials')
 /*
   This file is a reduced and adapted version of the main lib/internal/errors.js file defined at
 
-  https://github.com/nodejs/node/blob/master/lib/internal/errors.js
+  https://github.com/nodejs/node/blob/main/lib/internal/errors.js
 
   Don't try to replace with the original file and keep it up to date (starting from E(...) definitions)
   with the upstream file.

--- a/lib/ours/primordials.js
+++ b/lib/ours/primordials.js
@@ -7,7 +7,24 @@
 
   Don't try to replace with the original file and keep it up to date with the upstream file.
 */
+
+// This is a simplified version of AggregateError
+class AggregateError extends Error {
+  constructor(errors) {
+    if (!Array.isArray(errors)) {
+      throw new TypeError(`Expected input to be an Array, got ${typeof errors}`)
+    }
+    let message = ''
+    for (let i = 0; i < errors.length; i++) {
+      message += `    ${errors[i].stack}\n`
+    }
+    super(message)
+    this.name = 'AggregateError'
+    this.errors = errors
+  }
+}
 module.exports = {
+  AggregateError,
   ArrayIsArray(self) {
     return Array.isArray(self)
   },

--- a/lib/ours/primordials.js
+++ b/lib/ours/primordials.js
@@ -3,7 +3,7 @@
 /*
   This file is a reduced and adapted version of the main lib/internal/per_context/primordials.js file defined at
 
-  https://github.com/nodejs/node/blob/master/lib/internal/per_context/primordials.js
+  https://github.com/nodejs/node/blob/main/lib/internal/per_context/primordials.js
 
   Don't try to replace with the original file and keep it up to date with the upstream file.
 */

--- a/lib/ours/util.js
+++ b/lib/ours/util.js
@@ -5,7 +5,7 @@ const { format, inspect } = require('./util/inspect')
 const {
   codes: { ERR_INVALID_ARG_TYPE }
 } = require('./errors')
-const { kResistStopPropagation, SymbolDispose } = require('./primordials')
+const { kResistStopPropagation, AggregateError, SymbolDispose } = require('./primordials')
 const AbortSignal = globalThis.AbortSignal || require('abort-controller').AbortSignal
 const AbortController = globalThis.AbortController || require('abort-controller').AbortController
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
@@ -30,22 +30,6 @@ const validateAbortSignal = (signal, name) => {
 const validateFunction = (value, name) => {
   if (typeof value !== 'function') {
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value)
-  }
-}
-
-// This is a simplified version of AggregateError
-class AggregateError extends Error {
-  constructor(errors) {
-    if (!Array.isArray(errors)) {
-      throw new TypeError(`Expected input to be an Array, got ${typeof errors}`)
-    }
-    let message = ''
-    for (let i = 0; i < errors.length; i++) {
-      message += `    ${errors[i].stack}\n`
-    }
-    super(message)
-    this.name = 'AggregateError'
-    this.errors = errors
   }
 }
 module.exports = {

--- a/lib/ours/util.js
+++ b/lib/ours/util.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const bufferModule = require('buffer')
+const {
+  codes: { ERR_INVALID_ARG_TYPE }
+} = require('./errors')
 const { kResistStopPropagation, SymbolDispose } = require('./primordials')
 const AbortSignal = globalThis.AbortSignal || require('abort-controller').AbortSignal
 const AbortController = globalThis.AbortController || require('abort-controller').AbortController

--- a/lib/ours/util.js
+++ b/lib/ours/util.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const bufferModule = require('buffer')
+const { format, inspect } = require('./util/inspect')
 const {
   codes: { ERR_INVALID_ARG_TYPE }
 } = require('./errors')
@@ -88,50 +89,8 @@ module.exports = {
   debuglog() {
     return function () {}
   },
-  format(format, ...args) {
-    // Simplified version of https://nodejs.org/api/util.html#utilformatformat-args
-    return format.replace(/%([sdifj])/g, function (...[_unused, type]) {
-      const replacement = args.shift()
-      if (type === 'f') {
-        return replacement.toFixed(6)
-      } else if (type === 'j') {
-        return JSON.stringify(replacement)
-      } else if (type === 's' && typeof replacement === 'object') {
-        const ctor = replacement.constructor !== Object ? replacement.constructor.name : ''
-        return `${ctor} {}`.trim()
-      } else {
-        return replacement.toString()
-      }
-    })
-  },
-  inspect(value) {
-    // Vastly simplified version of https://nodejs.org/api/util.html#utilinspectobject-options
-    switch (typeof value) {
-      case 'string':
-        if (value.includes("'")) {
-          if (!value.includes('"')) {
-            return `"${value}"`
-          } else if (!value.includes('`') && !value.includes('${')) {
-            return `\`${value}\``
-          }
-        }
-        return `'${value}'`
-      case 'number':
-        if (isNaN(value)) {
-          return 'NaN'
-        } else if (Object.is(value, -0)) {
-          return String(value)
-        }
-        return value
-      case 'bigint':
-        return `${String(value)}n`
-      case 'boolean':
-      case 'undefined':
-        return String(value)
-      case 'object':
-        return '{}'
-    }
-  },
+  format,
+  inspect,
   types: {
     isAsyncFunction(fn) {
       return fn instanceof AsyncFunction

--- a/lib/ours/util/inspect.js
+++ b/lib/ours/util/inspect.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/*
+  This file is a reduced and adapted version of the main lib/internal/util/inspect.js file defined at
+
+  https://github.com/nodejs/node/blob/main/lib/internal/util/inspect.js
+
+  Don't try to replace with the original file and keep it up to date with the upstream file.
+*/
+module.exports = {
+  format(format, ...args) {
+    // Simplified version of https://nodejs.org/api/util.html#utilformatformat-args
+    return format.replace(/%([sdifj])/g, function (...[_unused, type]) {
+      const replacement = args.shift()
+      if (type === 'f') {
+        return replacement.toFixed(6)
+      } else if (type === 'j') {
+        return JSON.stringify(replacement)
+      } else if (type === 's' && typeof replacement === 'object') {
+        const ctor = replacement.constructor !== Object ? replacement.constructor.name : ''
+        return `${ctor} {}`.trim()
+      } else {
+        return replacement.toString()
+      }
+    })
+  },
+  inspect(value) {
+    // Vastly simplified version of https://nodejs.org/api/util.html#utilinspectobject-options
+    switch (typeof value) {
+      case 'string':
+        if (value.includes("'")) {
+          if (!value.includes('"')) {
+            return `"${value}"`
+          } else if (!value.includes('`') && !value.includes('${')) {
+            return `\`${value}\``
+          }
+        }
+        return `'${value}'`
+      case 'number':
+        if (isNaN(value)) {
+          return 'NaN'
+        } else if (Object.is(value, -0)) {
+          return String(value)
+        }
+        return value
+      case 'bigint':
+        return `${String(value)}n`
+      case 'boolean':
+      case 'undefined':
+        return String(value)
+      case 'object':
+        return '{}'
+    }
+  }
+}

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,8 +1,3 @@
-/* replacement start */
-
-const { Buffer } = require('buffer')
-
-/* replacement end */
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,7 +19,14 @@ const { Buffer } = require('buffer')
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-;('use strict')
+'use strict'
+
+/* replacement start */
+
+const { Buffer } = require('buffer')
+
+/* replacement end */
+
 const { ObjectDefineProperty, ObjectKeys, ReflectApply } = require('./ours/primordials')
 const {
   promisify: { custom: customPromisify }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { format, inspect, AggregateError: CustomAggregateError } = require('./util')
+const { format, inspect } = require('./util/inspect')
+const { AggregateError: CustomAggregateError } = require('./util')
 
 /*
   This file is a reduced and adapted version of the main lib/internal/errors.js file defined at

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { format, inspect } = require('./util/inspect')
-const { AggregateError: CustomAggregateError } = require('./util')
+const { AggregateError: CustomAggregateError } = require('./primordials')
 
 /*
   This file is a reduced and adapted version of the main lib/internal/errors.js file defined at

--- a/src/errors.js
+++ b/src/errors.js
@@ -6,7 +6,7 @@ const { AggregateError: CustomAggregateError } = require('./primordials')
 /*
   This file is a reduced and adapted version of the main lib/internal/errors.js file defined at
 
-  https://github.com/nodejs/node/blob/master/lib/internal/errors.js
+  https://github.com/nodejs/node/blob/main/lib/internal/errors.js
 
   Don't try to replace with the original file and keep it up to date (starting from E(...) definitions)
   with the upstream file.

--- a/src/primordials.js
+++ b/src/primordials.js
@@ -3,7 +3,7 @@
 /*
   This file is a reduced and adapted version of the main lib/internal/per_context/primordials.js file defined at
 
-  https://github.com/nodejs/node/blob/master/lib/internal/per_context/primordials.js
+  https://github.com/nodejs/node/blob/main/lib/internal/per_context/primordials.js
 
   Don't try to replace with the original file and keep it up to date with the upstream file.
 */

--- a/src/primordials.js
+++ b/src/primordials.js
@@ -8,7 +8,26 @@
   Don't try to replace with the original file and keep it up to date with the upstream file.
 */
 
+// This is a simplified version of AggregateError
+class AggregateError extends Error {
+  constructor(errors) {
+    if (!Array.isArray(errors)) {
+      throw new TypeError(`Expected input to be an Array, got ${typeof errors}`)
+    }
+
+    let message = ''
+    for (let i = 0; i < errors.length; i++) {
+      message += `    ${errors[i].stack}\n`
+    }
+
+    super(message)
+    this.name = 'AggregateError'
+    this.errors = errors
+  }
+}
+
 module.exports = {
+  AggregateError,
   ArrayIsArray(self) {
     return Array.isArray(self)
   },

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const bufferModule = require('buffer')
+const { format, inspect } = require('./util/inspect')
 const {
   codes: { ERR_INVALID_ARG_TYPE }
 } = require('./errors')
@@ -94,53 +95,8 @@ module.exports = {
   debuglog() {
     return function () {}
   },
-  format(format, ...args) {
-    // Simplified version of https://nodejs.org/api/util.html#utilformatformat-args
-    return format.replace(/%([sdifj])/g, function (...[_unused, type]) {
-      const replacement = args.shift()
-
-      if (type === 'f') {
-        return replacement.toFixed(6)
-      } else if (type === 'j') {
-        return JSON.stringify(replacement)
-      } else if (type === 's' && typeof replacement === 'object') {
-        const ctor = replacement.constructor !== Object ? replacement.constructor.name : ''
-        return `${ctor} {}`.trim()
-      } else {
-        return replacement.toString()
-      }
-    })
-  },
-  inspect(value) {
-    // Vastly simplified version of https://nodejs.org/api/util.html#utilinspectobject-options
-    switch (typeof value) {
-      case 'string':
-        if (value.includes("'")) {
-          if (!value.includes('"')) {
-            return `"${value}"`
-          } else if (!value.includes('`') && !value.includes('${')) {
-            return `\`${value}\``
-          }
-        }
-
-        return `'${value}'`
-      case 'number':
-        if (isNaN(value)) {
-          return 'NaN'
-        } else if (Object.is(value, -0)) {
-          return String(value)
-        }
-
-        return value
-      case 'bigint':
-        return `${String(value)}n`
-      case 'boolean':
-      case 'undefined':
-        return String(value)
-      case 'object':
-        return '{}'
-    }
-  },
+  format,
+  inspect,
   types: {
     isAsyncFunction(fn) {
       return fn instanceof AsyncFunction

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const bufferModule = require('buffer')
+const {
+  codes: { ERR_INVALID_ARG_TYPE }
+} = require('./errors')
 const { kResistStopPropagation, SymbolDispose } = require('./primordials')
 const AbortSignal = globalThis.AbortSignal || require('abort-controller').AbortSignal
 const AbortController = globalThis.AbortController || require('abort-controller').AbortController

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ const { format, inspect } = require('./util/inspect')
 const {
   codes: { ERR_INVALID_ARG_TYPE }
 } = require('./errors')
-const { kResistStopPropagation, SymbolDispose } = require('./primordials')
+const { kResistStopPropagation, AggregateError, SymbolDispose } = require('./primordials')
 const AbortSignal = globalThis.AbortSignal || require('abort-controller').AbortSignal
 const AbortController = globalThis.AbortController || require('abort-controller').AbortController
 
@@ -31,24 +31,6 @@ const validateAbortSignal = (signal, name) => {
 const validateFunction = (value, name) => {
   if (typeof value !== 'function') {
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value)
-  }
-}
-
-// This is a simplified version of AggregateError
-class AggregateError extends Error {
-  constructor(errors) {
-    if (!Array.isArray(errors)) {
-      throw new TypeError(`Expected input to be an Array, got ${typeof errors}`)
-    }
-
-    let message = ''
-    for (let i = 0; i < errors.length; i++) {
-      message += `    ${errors[i].stack}\n`
-    }
-
-    super(message)
-    this.name = 'AggregateError'
-    this.errors = errors
   }
 }
 

--- a/src/util/inspect.js
+++ b/src/util/inspect.js
@@ -1,0 +1,59 @@
+'use strict'
+
+/*
+  This file is a reduced and adapted version of the main lib/internal/util/inspect.js file defined at
+
+  https://github.com/nodejs/node/blob/main/lib/internal/util/inspect.js
+
+  Don't try to replace with the original file and keep it up to date with the upstream file.
+*/
+
+module.exports = {
+  format(format, ...args) {
+    // Simplified version of https://nodejs.org/api/util.html#utilformatformat-args
+    return format.replace(/%([sdifj])/g, function (...[_unused, type]) {
+      const replacement = args.shift()
+
+      if (type === 'f') {
+        return replacement.toFixed(6)
+      } else if (type === 'j') {
+        return JSON.stringify(replacement)
+      } else if (type === 's' && typeof replacement === 'object') {
+        const ctor = replacement.constructor !== Object ? replacement.constructor.name : ''
+        return `${ctor} {}`.trim()
+      } else {
+        return replacement.toString()
+      }
+    })
+  },
+  inspect(value) {
+    // Vastly simplified version of https://nodejs.org/api/util.html#utilinspectobject-options
+    switch (typeof value) {
+      case 'string':
+        if (value.includes("'")) {
+          if (!value.includes('"')) {
+            return `"${value}"`
+          } else if (!value.includes('`') && !value.includes('${')) {
+            return `\`${value}\``
+          }
+        }
+
+        return `'${value}'`
+      case 'number':
+        if (isNaN(value)) {
+          return 'NaN'
+        } else if (Object.is(value, -0)) {
+          return String(value)
+        }
+
+        return value
+      case 'bigint':
+        return `${String(value)}n`
+      case 'boolean':
+      case 'undefined':
+        return String(value)
+      case 'object':
+        return '{}'
+    }
+  }
+}


### PR DESCRIPTION
I noticed that the changes from #542 only affected `src/`, but not `lib/`. As such, [the latest 4.6.0 release](https://github.com/nodejs/readable-stream/releases/tag/v4.6.0) doesn't actually fix #541, since it still has [the bigint literal fyntax in `lib/ours/errors.js`](https://unpkg.com/browse/readable-stream@4.6.0/lib/ours/errors.js).

I wanted to fix this by rerunning `node build/build.mjs` locally. However, that surfaced a couple of more issues, which this PR aims to fix as well:
1. The regex for inserting headers was looking for `"use strict"` *only* on the very first line. However, most source files start with a copyright comment, so [the `"use strict"` directive only appears a few lines further](https://github.com/nodejs/node/blob/v18.19.0/lib/internal/streams/readable.js#L22). I fixed it by turning on the multiline flag on the regex.
2. `src/util.js` was using `ERR_INVALID_ARG_TYPE` without `require`ing it from `src/errors.js`. I added the missing require.
3. I reran Prettier and ESLint.
4. Finally, I reran `node build/build.mjs 18.19.0`.

I think we should have a test on our CI to verify that `lib/` has been correctly built using our build script. It's not always obvious to new contributors that `lib/` is generated code [(see review comment)](https://github.com/nodejs/readable-stream/pull/548#discussion_r1900059594), and it should (hopefully) prevent mistakes like #542 in the future.